### PR TITLE
make naviagation buttons clearer in company forms

### DIFF
--- a/frontend/components/CompanyForms/CompanyStep.vue
+++ b/frontend/components/CompanyForms/CompanyStep.vue
@@ -58,12 +58,12 @@ export default {
     backButtonName() {
       if (this.disableBackButton) return "Voltar";
       const tabName = this.items[this.tab - 1].tab;
-      return `Voltar para "${tabName}"`;
+      return `Voltar para aba "${tabName}"`;
     },
     nextButtonName() {
       if (this.disableNextButton) return "Próximo";
       const tabName = this.items[this.tab + 1].tab;
-      return `Ir para "${tabName}"`;
+      return `Ir para aba "${tabName}"`;
     },
     disableBackButton() {
       return this.tab === 0;

--- a/frontend/components/CompanyForms/Stepper.vue
+++ b/frontend/components/CompanyForms/Stepper.vue
@@ -25,7 +25,11 @@
           :key="id"
           :step="id"
         >
-          <component :is="component" :isUpdate=update class="component-border mb-12"></component>
+          <component
+            :is="component"
+            :is-update="update"
+            class="component-border mb-12"
+          ></component>
 
           <v-row class="mr-4" justify="end">
             <v-btn
@@ -59,10 +63,10 @@ export default {
     DNAUSPStep,
   },
   props: {
-   update: {
-     type: Boolean,
-     default: true,
-   }
+    update: {
+      type: Boolean,
+      default: true,
+    },
   },
   data: () => ({
     e1: 1,
@@ -82,7 +86,11 @@ export default {
     nextStepBtnText(id) {
       const length = this.numberOfSteps;
       const lastId = this.steps[length - 1].id;
-      return id < lastId ? "Seguir" : "Finalizar";
+
+      const nextStepIndex = this.steps.findIndex((step) => step.id === id) + 1;
+      const nextStepName = this.steps[nextStepIndex]?.title;
+
+      return id < lastId ? `Seguir para passo "${nextStepName}"` : "Finalizar";
     },
     isStepCompleted(number) {
       return this.e1 > number;


### PR DESCRIPTION
O formulário tem dois níveis de navegação (step e tab de "sobre empresa") que gera ambiguidade nos botões de navegação.

Deixei mais claro o que cada botão de "next" faz (próxima aba ou próximo passo)

Signed-off-by: João Daniel <jotaf.daniel@gmail.com>