### PR TITLE
remove block on displaying phone

### DIFF
--- a/frontend/components/CompanyForms/partnersStep/NewPartnerModal.vue
+++ b/frontend/components/CompanyForms/partnersStep/NewPartnerModal.vue
@@ -109,7 +109,7 @@ export default {
   watch: {
     updatedPartner() {
       this.formData = this.updatedPartner
-        ? Object.assign({}, { ...this.updatedPartner.partner, phone: "" })
+        ? Object.assign({}, { ...this.updatedPartner.partner })
         : {
             name: "",
             email: "",


### PR DESCRIPTION
phone information was being blocked due to lack of security in the update process

with the new process, this information is now longer risky to be exposed

Signed-off-by: João Daniel <jotaf.daniel@gmail.com>