### PR TITLE
Fix/initiatives

### DIFF
--- a/backend/app/controllers/company_updates_controller.rb
+++ b/backend/app/controllers/company_updates_controller.rb
@@ -74,6 +74,7 @@ class CompanyUpdatesController < ApplicationController
     prms[:partners].each_with_index do |raw_partner, index|
       partner = Partner.new(raw_partner.merge(index: index + 1))
       unless partner.valid?
+        errors[:partners] = partner.errors.full_messages
         partners_errors << partner.errors.full_messages
         has_error = true
       end

--- a/backend/app/models/partner.rb
+++ b/backend/app/models/partner.rb
@@ -35,7 +35,7 @@ class Partner
 
     is_valid = bonds.include?(bond)
 
-    errors.add(:bond) unless is_valid
+    errors.add(:bond, 'inválido. Tente atualizar o seu vínculo.') unless is_valid
   end
 
   def prepare_to_csv

--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Initiative.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Initiative.kt
@@ -10,7 +10,7 @@ data class Initiative(
     val name: String,
     val tags: Set<String>,
     val unity: String,
-    val url: String,
+    val url: String? = null,
 )
 
 @kotlinx.serialization.Serializable

--- a/server/discovery/src/main/kotlin/br/usp/inovacao/hubusp/server/discovery/JourneyRecord.kt
+++ b/server/discovery/src/main/kotlin/br/usp/inovacao/hubusp/server/discovery/JourneyRecord.kt
@@ -5,5 +5,5 @@ import kotlinx.serialization.Serializable
 @Serializable
 data class JourneyRecord(
     val name: String,
-    val url: String
+    val url: String? = null,
 )

--- a/server/hub-app/src/main/kotlin/br/usp/inovacao/hubusp/server/app/modules/Catalog.kt
+++ b/server/hub-app/src/main/kotlin/br/usp/inovacao/hubusp/server/app/modules/Catalog.kt
@@ -138,6 +138,7 @@ fun Application.catalog(db: MongoDatabase) {
         }
 
         get("/companies") {
+
             val params = call.request.queryParameters
 
             val companies = searchCompanies.search(params.toCompanySearchParams())
@@ -145,6 +146,11 @@ fun Application.catalog(db: MongoDatabase) {
             call.respond(
                 HttpStatusCode.OK,
                 mapOf("companies" to companies)
+            )
+
+            call.respond(
+                HttpStatusCode.OK,
+                mapOf("comapanies" to "oi")
             )
         }
 
@@ -159,7 +165,9 @@ fun Application.catalog(db: MongoDatabase) {
             )
         }
 
+
         get("/initiatives") {
+
             val params = call.request.queryParameters
 
             val initiatives = searchInitiatives.search(params.toInitiativeSearchParams())

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogInitiativeRepositoryImpl.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogInitiativeRepositoryImpl.kt
@@ -4,8 +4,10 @@ import br.usp.inovacao.hubusp.server.catalog.Contact
 import br.usp.inovacao.hubusp.server.catalog.Initiative
 import br.usp.inovacao.hubusp.server.catalog.InitiativeRepository
 import br.usp.inovacao.hubusp.server.catalog.InitiativeSearchParams
+import br.usp.inovacao.hubusp.server.persistence.models.DisciplineModel
 import br.usp.inovacao.hubusp.server.persistence.models.InitiativeContact
 import br.usp.inovacao.hubusp.server.persistence.models.InitiativeModel
+import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
 import org.litote.kmongo.find
 import org.litote.kmongo.getCollection
@@ -30,7 +32,11 @@ fun InitiativeModel.toCatalogInitiative(): Initiative = Initiative(
 class CatalogInitiativeRepositoryImpl(
     db: MongoDatabase
 ): InitiativeRepository {
-    private val initiativeCollection = db.getCollection<InitiativeModel>("iniciatives")
+    private val initiativeCollection : MongoCollection<InitiativeModel>
+
+    init {
+        initiativeCollection = db.getCollection<InitiativeModel>("iniciatives")
+    }
 
     override fun filter(params: InitiativeSearchParams): Set<Initiative> {
         val filter = params.toCollectionFilter()

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/models/InitiativeModel.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/models/InitiativeModel.kt
@@ -12,7 +12,7 @@ data class InitiativeModel(
     val name: String,
     val tags: Set<String>,
     val unity: String,
-    val url: String,
+    val url: String? = null,
 )
 
 @Serializable


### PR DESCRIPTION
Os dados não estavam sendo carregados na página de iniciativas (erro 500).
Nós acabamos descobrindo que o erro era o atributo Url do Initiative e InitiativeModel. Antes da nossa mudança, o atributo era String, e dava erro quando tentava ler as url's nulas do banco de dados.
Para compilar, tivemos que mudar o atributo no JourneyRecord também. 
