### PR TITLE
Set ecosystems to empty string when there is no incubator

### DIFF
--- a/frontend/components/CompanyForms/companyStep/Incubator.vue
+++ b/frontend/components/CompanyForms/companyStep/Incubator.vue
@@ -66,7 +66,11 @@ export default {
       ecosystems: "company_forms/ecosystems",
     }),
     disabledIncubatorsSelect() {
-      return this.incubated === "Não";
+      if (this.incubated === "Não") {
+        this.setEcosystems('')
+        return true
+      }
+      return false
     },
     defaultIncubators() {
       return this.incubadoras.includes(this.ecosystems) ? this.ecosystems : ''


### PR DESCRIPTION
Suponha que, no formulário de atualizações, os campos correspondentes às descrições "A empresa está ou esteve em alguma incubadora ou Parque tecnológico?" e "Se sim, em qual incubadora ou Parque Tecnológico?" foram preenchidos na última atualização feita pelo usuário. Se esse usuário deseja fazer uma nova atualização de modo que e a empresa NÃO tenha mais uma incubadora, então o código continua enviando o ecossistema para o backend (e o backend retorna um erro de validação, pois interpreta (corretamente) que é contraditório uma empresa NÃO estar incubada e, ainda assim, ter algum ecossistema).
Esse pull request checa se essa mudança (de empresa incubada para não incubada) foi feita e, nesse caso, envia um ecossistema vazio para o backend. Assim o usuário consegue finalizar o forms.


Signed-off-by: BrizaMel <brizamel.dias@gmail.com>
Co-authored-by: Marília Dicezare <mariliatd@gmail.com>