### PR TITLE
Fix DNA USP step message error formatting

### DIFF
--- a/frontend/store/company_forms/index.js
+++ b/frontend/store/company_forms/index.js
@@ -113,7 +113,7 @@ export const actions = {
     if (!getters.truthfulInformations) {
       commit("setErrors", {
         dna_usp_stamp:
-          "É necessário declarar que as informações fornecidas são verdadeiras e que a empresa atende aos critérios estabelecidos",
+          ["É necessário declarar que as informações fornecidas são verdadeiras e que a empresa atende aos critérios estabelecidos"],
       });
       return false;
     }


### PR DESCRIPTION
Antes a mensagem de erro aparecia assim:

• e
• r
• r
• o

agora aparece assim

• erro


Signed-off-by: BrizaMel <brizamel.dias@gmail.com>
Co-authored-by: Marília Dicezare <mariliatd@gmail.com>