### PR TITLE
Fix/discipline description

### DIFF
--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Discipline.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Discipline.kt
@@ -9,9 +9,16 @@ data class Category(
 )
 
 @kotlinx.serialization.Serializable
+data class Description(
+    val long: String,
+    val short: String,
+)
+
+@kotlinx.serialization.Serializable
 data class Discipline(
     val name: String,
     val category: Category,
+    val description: Description,
     val unity: String,
     val campus: String,
     val level: String,

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImpl.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImpl.kt
@@ -1,9 +1,11 @@
 package br.usp.inovacao.hubusp.server.persistence
 
 import br.usp.inovacao.hubusp.server.catalog.Category
+import br.usp.inovacao.hubusp.server.catalog.Description
 import br.usp.inovacao.hubusp.server.catalog.Discipline
 import br.usp.inovacao.hubusp.server.catalog.DisciplineSearchParams
 import br.usp.inovacao.hubusp.server.persistence.models.DisciplineCategory
+import br.usp.inovacao.hubusp.server.persistence.models.DisciplineDescription
 import br.usp.inovacao.hubusp.server.persistence.models.DisciplineModel
 import com.mongodb.client.MongoCollection
 import com.mongodb.client.MongoDatabase
@@ -17,9 +19,15 @@ fun DisciplineCategory.toCatalogCategory(): Category = Category(
     intellectual_property = this.intellectual_property
 )
 
+fun DisciplineDescription.toCatalogDescription(): Description = Description(
+    long = this.long,
+    short = this.short
+)
+
 fun DisciplineModel.toCatalogDiscipline(): Discipline = Discipline(
     name = this.name,
     category = this.category.toCatalogCategory(),
+    description = this.description.toCatalogDescription(),
     unity = this.unity,
     campus = this.campus,
     level = this.level,

--- a/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
+++ b/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
@@ -2,9 +2,8 @@ package br.usp.inovacao.hubusp.server.persistence
 
 import br.usp.inovacao.hubusp.server.catalog.Discipline
 import br.usp.inovacao.hubusp.server.catalog.DisciplineSearchParams
-import br.usp.inovacao.hubusp.server.persistence.models.DisciplineCategory
-import br.usp.inovacao.hubusp.server.persistence.models.DisciplineDescription
-import br.usp.inovacao.hubusp.server.persistence.models.DisciplineModel
+import br.usp.inovacao.hubusp.server.catalog.Initiative
+import br.usp.inovacao.hubusp.server.persistence.models.*
 import com.mongodb.client.MongoDatabase
 import org.litote.kmongo.deleteMany
 import org.litote.kmongo.getCollection
@@ -119,6 +118,40 @@ internal class CatalogDisciplineRepositoryImplTest {
         assertTrue { result.isNotEmpty() }
         assertTrue { result.all { it.name.contains(term) } }
     }
+
+    @Test
+    fun `it converts DisciplineModel into Discipline`() {
+        // given
+        val discipline = getDisciplineModelWithLongDescription()
+
+        // when
+        val result = discipline.toCatalogDiscipline()
+
+        // then
+        assertIs<Discipline>(result)
+    }
+
+    private fun getDisciplineModelWithLongDescription() =  DisciplineModel(
+        campus = "USP Leste",
+        category = DisciplineCategory(
+            innovation = false,
+            entrepreneurship = false,
+            business = false,
+            intellectual_property = true
+        ),
+        description = DisciplineDescription(
+            long = "Analisar as contribuições da inovação para o desenvolvimento do setor de serviços, ...",
+            short = ""
+        ),
+        keywords = setOf("foo", "baz"),
+        level = "Quero aprender!",
+        name = "ACH1575",
+        nature = "Graduação",
+        offeringPeriod = "N/D",
+        start_date = "",
+        unity = "Escola de Artes, Ciências e Humanidades - EACH",
+        url = ""
+    )
 
     private fun seedTestDb() {
         val disciplineCollection = testDb.getCollection<DisciplineModel>("disciplines")

--- a/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
+++ b/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
@@ -2,7 +2,6 @@ package br.usp.inovacao.hubusp.server.persistence
 
 import br.usp.inovacao.hubusp.server.catalog.Discipline
 import br.usp.inovacao.hubusp.server.catalog.DisciplineSearchParams
-import br.usp.inovacao.hubusp.server.catalog.Initiative
 import br.usp.inovacao.hubusp.server.persistence.models.*
 import com.mongodb.client.MongoDatabase
 import org.litote.kmongo.deleteMany


### PR DESCRIPTION
O ‘Item’ no frontend não recebia a descrição, fazendo o item.description retornar vazio. A descrição estava vazia, pois no back esse valor só existia no Model e não no Catalog. 
O valor foi adicionado no Discipline do Catalog e adicionei um teste para checar a conversão de DisciplineModel para Discipline com um long description.