### PR TITLE
Fix/incubation error message

### DIFF
--- a/backend/app/models/incubation.rb
+++ b/backend/app/models/incubation.rb
@@ -23,9 +23,10 @@ class Incubation
   end
 
   def consistent_pair?
+    return if was_incubated.nil? || was_incubated.eql?('')
+
     is_valid = both_negative? || both_positive?
 
-    errors.add(:was_incubated) unless is_valid
     errors.add(:ecosystem) unless is_valid
   end
 

--- a/frontend/plugins/services/update_company.js
+++ b/frontend/plugins/services/update_company.js
@@ -35,6 +35,9 @@ function translateErrorMessage(englishError) {
   if (englishError === "Wants inválido")
     return "Pedido de DNA USP inválido - necessário informar nome e email";
 
+  if (englishError === "Was incubated não pode estar em branco")
+    return "O primeiro campo de incubação não pode ser vazio";
+
   if (englishError === "Was incubated inválido")
     return "Empresas que foram ou estão incubadas devem informar a incubadora";
 


### PR DESCRIPTION
A mensagem de erro "Empresas que foram ou estão incubadas devem informar a incubadora" aparecia duas vezes, pois os dois erros 'was_incubated' e 'ecosystem' adicionados dependiam do mesmo valor de 'is_valid'. Além disso, a mensagem também aparecia duplicada no caso em que o primeiro campo de incubação fosse apagado e ficasse vazio no formulário de atualização.
A mensagem de erro caso o primeiro campo de incubação fosse vazio não tinha sido traduzida.