### PR TITLE
Fix/discipline url

### DIFF
--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Discipline.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Discipline.kt
@@ -22,5 +22,6 @@ data class Discipline(
     val unity: String,
     val campus: String,
     val level: String,
-    val nature: String
+    val nature: String,
+    val url: String
 )

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImpl.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImpl.kt
@@ -31,7 +31,8 @@ fun DisciplineModel.toCatalogDiscipline(): Discipline = Discipline(
     unity = this.unity,
     campus = this.campus,
     level = this.level,
-    nature = this.nature
+    nature = this.nature,
+    url = this.url
 )
 
 class CatalogDisciplineRepositoryImpl(

--- a/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
+++ b/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
@@ -121,7 +121,7 @@ internal class CatalogDisciplineRepositoryImplTest {
     @Test
     fun `it converts DisciplineModel into Discipline`() {
         // given
-        val discipline = getDisciplineModelWithLongDescription()
+        val discipline = getDisciplineModel()
 
         // when
         val result = discipline.toCatalogDiscipline()
@@ -130,7 +130,7 @@ internal class CatalogDisciplineRepositoryImplTest {
         assertIs<Discipline>(result)
     }
 
-    private fun getDisciplineModelWithLongDescription() =  DisciplineModel(
+    private fun getDisciplineModel() =  DisciplineModel(
         campus = "USP Leste",
         category = DisciplineCategory(
             innovation = false,
@@ -149,7 +149,7 @@ internal class CatalogDisciplineRepositoryImplTest {
         offeringPeriod = "N/D",
         start_date = "",
         unity = "Escola de Artes, Ciências e Humanidades - EACH",
-        url = ""
+        url = "https://uspdigital.usp.br/jupiterweb/obterDisciplina?sgldis=ACH2008&nomdis="
     )
 
     private fun seedTestDb() {


### PR DESCRIPTION
A url 'saiba mais' das disciplinas em educação não estava funcionando, pois ela não estava definida em Discipline no Catálogo. Problema similar ao anterior da descrição de disciplinas.