### PR TITLE
Fix/discipline offering period

### DIFF
--- a/frontend/modules/Catalog/components/DropdownFilter.vue
+++ b/frontend/modules/Catalog/components/DropdownFilter.vue
@@ -110,7 +110,7 @@ export default {
     colSize() {
       const nGroups = this.groups.length;
 
-      return nGroups > 4 ? Math.floor(12 / nGroups) : 3;
+      return nGroups > 4 ? (12 / nGroups) : 3;
     },
   },
   watch: {

--- a/frontend/modules/Catalog/pages/educacao.vue
+++ b/frontend/modules/Catalog/pages/educacao.vue
@@ -125,6 +125,21 @@ export default {
           label: "Natureza",
           items: ["Graduação", "Pós-graduação"],
         },
+        {
+          label: "Período de Oferecimento",
+          items: Array.from(
+            this.disciplines.reduce((acc, discipline) => {
+              const offeringPeriod = discipline.offeringPeriod;
+              if (
+                offeringPeriod &&
+                !acc.has(offeringPeriod) &&
+                offeringPeriod != "N/D"
+              )
+                acc.add(offeringPeriod);
+              return acc;
+            }, new Set())
+          ),
+        },
       ];
     },
     searchTerm() {
@@ -137,6 +152,7 @@ export default {
         unity: this.filters?.terciary[1],
         level: this.filters?.terciary[2],
         nature: this.filters?.terciary[3],
+        offeringPeriod: this.filters?.terciary[4],
         term: this.searchTerm,
       };
     },

--- a/frontend/modules/Catalog/pages/educacao.vue
+++ b/frontend/modules/Catalog/pages/educacao.vue
@@ -28,7 +28,7 @@
         <v-container>
           <p class="body-2">{{ item.campus }}</p>
           <p class="body-2">{{ item.unity }}</p>
-          <p class="body-2">{{ item.offeringPeriod }}</p>
+          <NDText :text="item.offeringPeriod" label=""/>
           <p class="body-2">{{ item.nature }}</p>
         </v-container>
       </template>
@@ -53,6 +53,7 @@ import Background from "../components/Background.vue";
 import Panel from "../components/Panel.vue";
 import MultipleFilters from "../components/MultipleFilters.vue";
 import DisplayData from "../components/DisplayData.vue";
+import NDText from "../components/NDText.vue";
 
 import { debounce } from "debounce";
 
@@ -62,6 +63,7 @@ export default {
     Background,
     MultipleFilters,
     DisplayData,
+    NDText,
   },
   data: () => ({
     search: { term: "" },
@@ -130,11 +132,8 @@ export default {
           items: Array.from(
             this.disciplines.reduce((acc, discipline) => {
               const offeringPeriod = discipline.offeringPeriod;
-              if (
-                offeringPeriod &&
-                !acc.has(offeringPeriod) &&
-                offeringPeriod != "N/D"
-              )
+              const hasPeriod = offeringPeriod && !acc.has(offeringPeriod) && offeringPeriod != "N/D"
+              if (hasPeriod)
                 acc.add(offeringPeriod);
               return acc;
             }, new Set())

--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Discipline.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Discipline.kt
@@ -23,5 +23,6 @@ data class Discipline(
     val campus: String,
     val level: String,
     val nature: String,
-    val url: String
+    val url: String,
+    val offeringPeriod: String
 )

--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/DisciplineSearchParams.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/DisciplineSearchParams.kt
@@ -6,5 +6,6 @@ data class DisciplineSearchParams(
     val unity: String? = null,
     val level: String? = null,
     val nature: String? = null,
-    val term: String? = null,
+    val offeringPeriod: String? = null,
+    val term: String? = null
 )

--- a/server/hub-app/src/main/kotlin/br/usp/inovacao/hubusp/server/app/modules/Catalog.kt
+++ b/server/hub-app/src/main/kotlin/br/usp/inovacao/hubusp/server/app/modules/Catalog.kt
@@ -55,6 +55,7 @@ fun Parameters.toDisciplineSearchParams() = DisciplineSearchParams(
     unity = this["unity"],
     level = this["level"],
     nature = this["nature"],
+    offeringPeriod = this["offeringPeriod"],
     term = this["term"],
 )
 

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImpl.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImpl.kt
@@ -32,7 +32,8 @@ fun DisciplineModel.toCatalogDiscipline(): Discipline = Discipline(
     campus = this.campus,
     level = this.level,
     nature = this.nature,
-    url = this.url
+    url = this.url,
+    offeringPeriod = this.offeringPeriod
 )
 
 class CatalogDisciplineRepositoryImpl(

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/disciplineExtension.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/disciplineExtension.kt
@@ -11,6 +11,7 @@ fun DisciplineSearchParams.toCollectionFilter(): String {
     if (campus != null) inner.add("\"campus\":\"$campus\"")
     if (level != null) inner.add("\"level\":\"$level\"")
     if (nature != null) inner.add("\"nature\":\"$nature\"")
+    if (offeringPeriod != null) inner.add("\"offeringPeriod\":\"$offeringPeriod\"")
 
     if (term != null) inner.add("\"\$text\":{\"\$search\":\"$term\"}")
 

--- a/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
+++ b/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogDisciplineRepositoryImplTest.kt
@@ -93,6 +93,19 @@ internal class CatalogDisciplineRepositoryImplTest {
     }
 
     @Test
+    fun `it filters by offering period`() {
+        // given
+        val givenPeriod = "1º sem. 2023"
+        val params = DisciplineSearchParams(offeringPeriod = givenPeriod)
+
+        // when
+        val result = underTest.filter(params)
+
+        // then
+        assertTrue { result.all { it.offeringPeriod == givenPeriod } }
+    }
+
+    @Test
     fun `it filters by category`() {
         // given
         val params = DisciplineSearchParams(categories = setOf("Negócios","Empreendedorismo"))
@@ -180,7 +193,7 @@ internal class CatalogDisciplineRepositoryImplTest {
                 short = ""
             ),
             keywords = setOf("foo", "baz"),
-            offeringPeriod = "N/D",
+            offeringPeriod = "1º sem. 2023",
             start_date = "",
             url = ""
         ),
@@ -243,7 +256,7 @@ internal class CatalogDisciplineRepositoryImplTest {
                 short = ""
             ),
             keywords = setOf("foo", "baz"),
-            offeringPeriod = "N/D",
+            offeringPeriod = "2º sem. 2022",
             start_date = "",
             url = ""
         )


### PR DESCRIPTION
O filtro do período de oferecimento não estava aparecendo na página de disciplinas, pois o offeringPeriod não estava presente no Discipline do Catálogo e não estava definido como parâmetro de busca no back.
Além disso, faltava o dropdown deste filtro no front.