### PR TITLE
Add mask to phone number in Company Forms

### DIFF
--- a/frontend/components/CompanyForms/companyStep/Base.vue
+++ b/frontend/components/CompanyForms/companyStep/Base.vue
@@ -68,7 +68,8 @@
           <MultipleInputs
             :value="phones"
             input-label="Telefone comercial"
-            component="ShortTextInput"
+            component="MaskInput"
+            mask="(##) #########"
             @input="setPhones"
           />
           <p class="body-2 mt-5">Emails</p>


### PR DESCRIPTION
In Company Forms, Add new contact phone format to use mask, this change will prevent the user to type incorrect phone type