### PR TITLE
Add "registry status" company field with tests

### DIFF
--- a/backend/app/models/company_datum.rb
+++ b/backend/app/models/company_datum.rb
@@ -8,6 +8,7 @@ class CompanyDatum
   field :corporate_name, type: String
   field :year, type: Integer
   field :cnae, type: String
+  field :registry_status, type: String
   field :phones, type: Array
   field :emails, type: Array
   field :street, type: String
@@ -22,9 +23,24 @@ class CompanyDatum
   validates :emails, emails: true
 
   validate :not_empty_public_name?, :not_empty_corporate_name?, :current_or_past_year?,
-           :valid_zipcode?, :array_of_cities?
+           :valid_zipcode?, :array_of_cities?, :valid_registry_status?
 
   embedded_in :company_update_request, inverse_of: :company_data
+
+  def valid_registry_status?
+    return if registry_status.nil?
+
+    registry_options = [
+      'Ativa',
+      'Ativa Não Regular',
+      'Baixada',
+      'Inapta',
+      'Nula',
+      'Suspensa'
+    ]
+
+    errors.add(:registry_status) unless registry_options.include?(registry_status)
+  end
 
   def array_of_cities?
     errors.add(:city) unless city.is_a?(Array)
@@ -59,6 +75,7 @@ class CompanyDatum
       'Razão Social',
       'Ano de fundação',
       'CNAE',
+      'Situação cadastral',
       'Telefones',
       'Emails',
       'Endereço',
@@ -76,6 +93,7 @@ class CompanyDatum
       corporate_name,
       year,
       cnae,
+      registry_status,
       phones_to_csv,
       emails_to_csv,
       street,

--- a/backend/app/models/company_datum.rb
+++ b/backend/app/models/company_datum.rb
@@ -42,7 +42,7 @@ class CompanyDatum
 
     errors.add(:registry_status) unless registry_options.include?(registry_status)
   end
-  
+
   def invalid_size_name?
     return if size.nil?
 

--- a/backend/app/views/application_mailer/confirmation_company_update.html.erb
+++ b/backend/app/views/application_mailer/confirmation_company_update.html.erb
@@ -11,6 +11,7 @@
 <p><strong>CNPJ:</strong> <%= @update_data.company_data.cnpj %></p>
 <p><strong>Ano:</strong> <%= @update_data.company_data.year %></p>
 <p><strong>CNAE:</strong> <%= @update_data.company_data.cnae %></p>
+<p><strong>Situação cadastral:</strong> <%= @update_data.company_data.registry_status %></p>
 <p><strong>Telefones:</strong></p>
 <ul>
   <%@update_data.company_data.phones.each do |phone| %>

--- a/backend/spec/models/company_datum_spec.rb
+++ b/backend/spec/models/company_datum_spec.rb
@@ -119,6 +119,11 @@ RSpec.describe CompanyDatum, type: :model do
         expect(described_class.new(attrs)).to be_valid
       end
     end
+
+    it 'on missing registry_status' do
+      attrs[:registry_status] = nil
+      expect(described_class.new(attrs)).to be_valid
+    end
   end
 
   context 'with CSV preparation' do

--- a/backend/spec/models/company_datum_spec.rb
+++ b/backend/spec/models/company_datum_spec.rb
@@ -10,6 +10,7 @@ RSpec.describe CompanyDatum, type: :model do
       corporate_name: 'benefit of testing rails and other apps',
       year: 2019,
       cnae: '99.21-3-54',
+      registry_status: 'Ativa',
       phones: [
         '(11) 99999-4433'
       ],
@@ -25,6 +26,15 @@ RSpec.describe CompanyDatum, type: :model do
   end
 
   context 'with validation errors' do
+    it 'on invalid registry status' do
+      attrs[:registry_status] = 'bar'
+      expect(described_class.new(attrs)).to be_invalid
+    end
+
+    it 'on inexistent attribute registry status' do
+      expect(attrs).to include(:registry_status)
+    end
+
     it 'on string city' do
       attrs[:city] = 'foo'
       expect { described_class.new(attrs) }.to raise_error(Mongoid::Errors::InvalidValue)
@@ -101,6 +111,14 @@ RSpec.describe CompanyDatum, type: :model do
         end
       end
     end
+
+    ['Ativa', 'Ativa Não Regular', 'Baixada',
+     'Inapta', 'Nula', 'Suspensa'].each do |val|
+      it "with registry status #{val}" do
+        attrs[:registry_status] = val
+        expect(described_class.new(attrs)).to be_valid
+      end
+    end
   end
 
   context 'with CSV preparation' do
@@ -112,6 +130,7 @@ RSpec.describe CompanyDatum, type: :model do
         attrs[:corporate_name],
         attrs[:year],
         attrs[:cnae],
+        attrs[:registry_status],
         attrs[:phones].join(';'),
         attrs[:emails].join(';'),
         attrs[:street],

--- a/backend/spec/models/company_datum_spec.rb
+++ b/backend/spec/models/company_datum_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe CompanyDatum, type: :model do
     it 'on inexistent attribute registry status' do
       expect(attrs).to include(:registry_status)
     end
-    
+
     it 'on invalid size name' do
       attrs[:size] = 'Abacate'
       expect(described_class.new(attrs)).to be_invalid

--- a/frontend/components/CompanyForms/companyStep/Base.vue
+++ b/frontend/components/CompanyForms/companyStep/Base.vue
@@ -32,6 +32,12 @@
             @input="setCnpj"
             :disabled="true"
           />
+          <Dropdown
+            :value="registry_status"
+            label="Situação cadastral"
+            :options="allRegistryStatus"
+            @input="setRegistryStatus"
+          />
         </v-container>
       </div>
 
@@ -131,6 +137,14 @@ export default {
   },
   data: () => ({
     allStates: [],
+    allRegistryStatus: [
+      "Ativa",
+      "Ativa Não Regular",
+      "Baixada",
+      "Inapta",
+      "Nula",
+      "Suspensa"
+    ],
   }),
   computed: {
     ...mapGetters({
@@ -139,6 +153,7 @@ export default {
       year: "company_forms/year",
       cnpj: "company_forms/cnpj",
       cnae: "company_forms/cnae",
+      registry_status: "company_forms/registry_status",
       phones: "company_forms/phones",
       emails: "company_forms/emails",
       address: "company_forms/address",
@@ -159,6 +174,7 @@ export default {
       setYear: "company_forms/setYear",
       setCnpj: "company_forms/setCnpj",
       setCnae: "company_forms/setCnae",
+      setRegistryStatus: "company_forms/setRegistryStatus",
       setPhones: "company_forms/setPhones",
       setEmails: "company_forms/setEmails",
       setVenue: "company_forms/setVenue",

--- a/frontend/store/company_forms/company_data.js
+++ b/frontend/store/company_forms/company_data.js
@@ -4,6 +4,7 @@ const state = () => ({
   year: "",
   cnpj: "",
   cnae: "",
+  registry_status: null,
   phones: [],
   emails: [],
   address: {
@@ -21,6 +22,7 @@ const getters = {
   year: (s) => s.year,
   cnpj: (s) => s.cnpj,
   cnae: (s) => s.cnae,
+  registry_status: (s) => s.registry_status,
   phones: (s) => s.phones,
   emails: (s) => s.emails,
   address: (s) => s.address,
@@ -47,6 +49,8 @@ const actions = {
     commit("setFormField", { key: "cnpj", value }),
   setCnae: ({ commit }, value) =>
     commit("setFormField", { key: "cnae", value }),
+  setRegistryStatus: ({ commit }, value) =>
+    commit("setFormField", { key: "registry_status", value }),
   setPhones: ({ commit }, value) =>
     commit("setFormField", { key: "phones", value }),
   setEmails: ({ commit }, value) =>
@@ -87,6 +91,7 @@ const prepareSection = (obj) => ({
     corporate_name: obj.corporateName,
     year: obj.year,
     cnae: obj.cnae,
+    registry_status: obj.registry_status,
     phones: obj.phones,
     emails: obj.emails,
     street: obj.address.venue,

--- a/frontend/store/company_forms/company_data.js
+++ b/frontend/store/company_forms/company_data.js
@@ -4,7 +4,7 @@ const state = () => ({
   year: "",
   cnpj: "",
   cnae: "",
-  registry_status: null,
+  registry_status: "",
   phones: [],
   emails: [],
   address: {


### PR DESCRIPTION
- Adiciona campo de situação cadastral no formulário do _frontend_, com as respectivas funções de _get_ and _set_.
- Adiciona novo atributo do modelo de dados das empresas com o campo de situação cadastral.
- Adiciona testes para o modelo do novo campo no _backend_.
- Adiciona campo de situação cadastral no e-mail enviado pela _view_ do _backend_.