### PR TITLE
Add field "company nature" on company update form

### DIFF
--- a/backend/app/models/company_datum.rb
+++ b/backend/app/models/company_datum.rb
@@ -15,6 +15,7 @@ class CompanyDatum
   field :city, type: Array
   field :state, type: String
   field :zipcode, type: String
+  field :company_nature, type: String
 
   validates :cnpj, cnpj: true, presence: true
   validates :cnae, cnae: true
@@ -22,9 +23,17 @@ class CompanyDatum
   validates :emails, emails: true
 
   validate :not_empty_public_name?, :not_empty_corporate_name?, :current_or_past_year?,
-           :valid_zipcode?, :array_of_cities?
+           :valid_zipcode?, :array_of_cities?, :valid_company_nature?
 
   embedded_in :company_update_request, inverse_of: :company_data
+
+  def valid_company_nature?
+    return if company_nature.nil?
+
+    is_valid = company_nature.match?(/\A\d{3}-\d{1}\s-\s([A-zÀ-ú0-9_ ()-]*)\Z/)
+
+    errors.add(:company_nature) unless is_valid
+  end
 
   def array_of_cities?
     errors.add(:city) unless city.is_a?(Array)
@@ -65,7 +74,8 @@ class CompanyDatum
       'Bairro',
       'Cidade',
       'Estado',
-      'CEP'
+      'CEP',
+      'Natureza Jurídica'
     ]
   end
 
@@ -82,7 +92,8 @@ class CompanyDatum
       neighborhood,
       city,
       state,
-      zipcode
+      zipcode,
+      company_nature
     ]
   end
 

--- a/backend/app/models/company_datum.rb
+++ b/backend/app/models/company_datum.rb
@@ -30,7 +30,7 @@ class CompanyDatum
   embedded_in :company_update_request, inverse_of: :company_data
 
   def valid_company_nature?
-    return if company_nature.nil?
+    return if company_nature.blank?
 
     is_valid = company_nature.match?(/\A\d{3}-\d{1}\s-\s([A-zÀ-ú0-9_ ()-]*)\Z/)
 

--- a/backend/app/models/company_datum.rb
+++ b/backend/app/models/company_datum.rb
@@ -32,7 +32,7 @@ class CompanyDatum
   def valid_company_nature?
     return if company_nature.blank?
 
-    is_valid = company_nature.match?(/\A\d{3}-\d{1}\s-\s([A-zÀ-ú0-9_ ()-]*)\Z/)
+    is_valid = company_nature.match?(/\A\d{3}-\d{1}\s-\s+(?=\S)([A-zÀ-ú0-9_ ()-]+)\Z/)
 
     errors.add(:company_nature) unless is_valid
   end

--- a/backend/app/views/application_mailer/confirmation_company_update.html.erb
+++ b/backend/app/views/application_mailer/confirmation_company_update.html.erb
@@ -10,6 +10,7 @@
 <p><strong>Razão Social:</strong> <%= @update_data.company_data.corporate_name %></p>
 <p><strong>CNPJ:</strong> <%= @update_data.company_data.cnpj %></p>
 <p><strong>Ano:</strong> <%= @update_data.company_data.year %></p>
+<p><strong>Natureza Jurídica:</strong> <%= @update_data.company_data.company_nature %></p>
 <p><strong>CNAE:</strong> <%= @update_data.company_data.cnae %></p>
 <p><strong>Telefones:</strong></p>
 <ul>

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -13,6 +13,7 @@ pt-br:
         public_name: Nome Fantasia
         corporate_name: Razão Social
         zipcode: Código Postal (CEP)
+        company_nature: Natureza jurídica da empresa
       discipline:
         name: Nome
         unity: Unidade

--- a/backend/spec/models/company_datum_spec.rb
+++ b/backend/spec/models/company_datum_spec.rb
@@ -20,11 +20,16 @@ RSpec.describe CompanyDatum, type: :model do
       neighborhood: 'vila vegetal',
       city: ['fito'],
       state: 'plantae',
-      zipcode: '04331-000'
+      zipcode: '04331-000',
+      company_nature: '000-0 - Indústria de Testes Automatizados'
     }
   end
 
   context 'with validation errors' do
+    it 'on inexistent attribute company nature' do
+      expect(attrs).to include(:company_nature)
+    end
+
     it 'on string city' do
       attrs[:city] = 'foo'
       expect { described_class.new(attrs) }.to raise_error(Mongoid::Errors::InvalidValue)
@@ -118,7 +123,8 @@ RSpec.describe CompanyDatum, type: :model do
         attrs[:neighborhood],
         attrs[:city],
         attrs[:state],
-        attrs[:zipcode]
+        attrs[:zipcode],
+        attrs[:company_nature]
       ]
     end
 

--- a/backend/spec/models/company_datum_spec.rb
+++ b/backend/spec/models/company_datum_spec.rb
@@ -37,6 +37,11 @@ RSpec.describe CompanyDatum, type: :model do
       expect(described_class.new(attrs)).to be_invalid
     end
 
+    it 'on empty string of company nature' do
+      attrs[:company_nature] = '000-0 - '
+      expect(described_class.new(attrs)).to be_invalid
+    end
+
     it 'on invalid registry status' do
       attrs[:registry_status] = 'bar'
       expect(described_class.new(attrs)).to be_invalid

--- a/backend/spec/models/company_datum_spec.rb
+++ b/backend/spec/models/company_datum_spec.rb
@@ -32,6 +32,11 @@ RSpec.describe CompanyDatum, type: :model do
       expect(attrs).to include(:company_nature)
     end
 
+    it 'on invalid company nature' do
+      attrs[:company_nature] = 'foo'
+      expect(described_class.new(attrs)).to be_invalid
+    end
+
     it 'on invalid registry status' do
       attrs[:registry_status] = 'bar'
       expect(described_class.new(attrs)).to be_invalid
@@ -133,6 +138,16 @@ RSpec.describe CompanyDatum, type: :model do
 
     it 'on missing registry_status' do
       attrs[:registry_status] = nil
+      expect(described_class.new(attrs)).to be_valid
+    end
+
+    it 'on missing company_nature' do
+      attrs[:company_nature] = nil
+      expect(described_class.new(attrs)).to be_valid
+    end
+
+    it 'on company_nature' do
+      attrs[:company_nature] = '123-4 - Automatização'
       expect(described_class.new(attrs)).to be_valid
     end
 

--- a/frontend/components/CompanyForms/companyStep/Base.vue
+++ b/frontend/components/CompanyForms/companyStep/Base.vue
@@ -36,6 +36,37 @@
       </div>
 
       <div class="mt-8 text-h6 font-weight-regular">
+        Código e Descrição da Natureza Jurídica da empresa
+        <v-divider />
+        <v-container>
+          <legend class="body-2 mb-5">
+            Para consultar o código e a natureza jurídica da empresa, cole o CNPJ da empresa no
+            <a
+              href="http://servicos.receita.fazenda.gov.br/Servicos/cnpjreva/Cnpjreva_Solicitacao.asp?cnpj"
+              target="_blank"
+              >site da receita</a
+            >. Depois copie o CÓDIGO e a DESCRIÇÃO DA NATUREZA JURÍDICA e cole
+            como resposta nos campos abaixo. Insira apenas o código no formato
+            "000-0" e a descrição no formato de texto. A lista de códigos e naturezas jurídicas
+            pode ser encontrada na
+            <a
+              href="https://concla.ibge.gov.br/estrutura/natjur-estrutura/natureza-juridica-2021"
+              target="_blank"
+              >tabela de naturezas jurídicas do IBGE</a
+            >.
+          </legend>
+          <PairOfNumberAndText
+            :value="companyNature"
+            labelOne="Código"
+            labelTwo="Natureza Jurídica"
+            placeholderOne="000-0"
+            separator=" - "
+            @input="setCompanyNature"
+          />
+        </v-container>
+      </div>
+
+      <div class="mt-8 text-h6 font-weight-regular">
         CNAE (Classificação Nacional de Atividades Econômicas) da empresa
         <v-divider />
         <v-container>
@@ -121,6 +152,7 @@ import MultipleInputs from "@/components/CompanyForms/inputs/MultipleInputs.vue"
 import MaskInput from "@/components/CompanyForms/inputs/MaskInput.vue";
 import ShortTextInput from "@/components/CompanyForms/inputs/ShortTextInput.vue";
 import Dropdown from "@/components/CompanyForms/inputs/Dropdown.vue";
+import PairOfNumberAndText from "@/components/CompanyForms/inputs/PairOfNumberAndText.vue";
 
 export default {
   components: {
@@ -128,6 +160,7 @@ export default {
     MultipleInputs,
     ShortTextInput,
     Dropdown,
+    PairOfNumberAndText,
   },
   data: () => ({
     allStates: [],
@@ -147,6 +180,7 @@ export default {
       city: "company_forms/city",
       state: "company_forms/state",
       cep: "company_forms/cep",
+      companyNature: "company_forms/companyNature",
     }),
   },
   created() {
@@ -166,6 +200,7 @@ export default {
       setCity: "company_forms/setCity",
       setState: "company_forms/setState",
       setCep: "company_forms/setCep",
+      setCompanyNature: "company_forms/setCompanyNature",
     }),
     async getStates() {
       const response = await fetch(

--- a/frontend/components/CompanyForms/inputs/MaskInput.vue
+++ b/frontend/components/CompanyForms/inputs/MaskInput.vue
@@ -8,6 +8,7 @@
       :value="value"
       :disabled="disabled"
       :hint="hint"
+      :placeholder="placeholder"
       persistent-hint
       @input="$emit('input', $event)"
     />
@@ -41,6 +42,11 @@ export default {
       default: () => false,
     },
     hint: {
+      type: String,
+      required: false,
+      default: () => "",
+    },
+    placeholder: {
       type: String,
       required: false,
       default: () => "",

--- a/frontend/components/CompanyForms/inputs/PairOfNumberAndText.vue
+++ b/frontend/components/CompanyForms/inputs/PairOfNumberAndText.vue
@@ -1,0 +1,83 @@
+<template>
+  <v-row>
+    <v-col>
+      <MaskInput
+        :placeholder="placeholderOne"
+        :value="one"
+        mask="###-#"
+        :label="labelOne"
+        v-model="one"
+      />
+    </v-col>
+    <v-col cols="10">
+      <ShortTextInput
+        :placeholder="placeholderTwo"
+        :value="two"
+        :label="labelTwo"
+        v-model="two"
+      />
+    </v-col>
+  </v-row>
+</template>
+
+<script>
+import ShortTextInput from "@/components/CompanyForms/inputs/ShortTextInput.vue";
+import MaskInput from "@/components/CompanyForms/inputs/MaskInput.vue";
+
+export default {
+  name: "PairOfNumberAndText",
+  components: {
+    ShortTextInput,
+    MaskInput
+  },
+  data: () => ({
+    one: "",
+    two: "",
+  }),
+  props: {
+    placeholderOne: {
+      type: String,
+      default: () => "",
+    },
+    placeholderTwo: {
+      type: String,
+      default: () => "",
+    },
+    labelOne: {
+      type: String,
+      default: () => "label one",
+    },
+    labelTwo: {
+      type: String,
+      default: () => "label two",
+    },
+    separator: {
+      type: String,
+      default: () => " ",
+    },
+    value: {
+      type: String,
+    }
+  },
+  computed: {
+    inputEvent() {
+      return `${this.one}${this.separator}${this.two}`;
+    },
+    splitValues() {
+      if (this.value) {
+        const split = this.value.split(this.separator);
+        this.one = split[0];
+        this.two = split[1];
+      }
+    },
+  },
+  watch: {
+    one() {
+      this.$emit("input", this.inputEvent);
+    },
+    two() {
+      this.$emit("input", this.inputEvent);
+    },
+  },
+};
+</script>

--- a/frontend/components/CompanyForms/inputs/ShortTextInput.vue
+++ b/frontend/components/CompanyForms/inputs/ShortTextInput.vue
@@ -6,7 +6,6 @@
     :label="label"
     :hint="hint"
     persistent-hint
-    :placeholder="placeholder"
     @input="$emit('input', $event)"
   />
 </template>
@@ -27,11 +26,6 @@ export default {
     },
     value: {
       type: String,
-    },
-    placeholder: {
-      type: String,
-      required: false,
-      default: () => "",
     },
     label: {
       type: String,

--- a/frontend/components/CompanyForms/inputs/ShortTextInput.vue
+++ b/frontend/components/CompanyForms/inputs/ShortTextInput.vue
@@ -6,6 +6,7 @@
     :label="label"
     :hint="hint"
     persistent-hint
+    :placeholder="placeholder"
     @input="$emit('input', $event)"
   />
 </template>
@@ -26,6 +27,11 @@ export default {
     },
     value: {
       type: String,
+    },
+    placeholder: {
+      type: String,
+      required: false,
+      default: () => "",
     },
     label: {
       type: String,

--- a/frontend/plugins/services/update_company.js
+++ b/frontend/plugins/services/update_company.js
@@ -55,6 +55,8 @@ function translateErrorMessage(englishError) {
 
   if (englishError === "Year inválido") return "Ano de criação inválido";
 
+  if (englishError === "Company nature inválido") return "Natureza jurídica da empresa inválida";
+
   return englishError;
 }
 

--- a/frontend/store/company_forms/company_data.js
+++ b/frontend/store/company_forms/company_data.js
@@ -13,6 +13,7 @@ const state = () => ({
     state: "",
     cep: "",
   },
+  company_nature: "",
 });
 
 const getters = {
@@ -29,6 +30,7 @@ const getters = {
   city: (s) => s.address.city,
   state: (s) => s.address.state,
   cep: (s) => s.address.cep,
+  company_nature: (s) => s.company_nature,
 };
 
 const mutations = {
@@ -78,6 +80,8 @@ const actions = {
       key: "address",
       value: { ...getters.address, cep: value },
     }),
+  setCompanyNature: ({ commit }, value) =>
+    commit("setFormField", { key: "company_nature", value }),
 };
 
 const prepareSection = (obj) => ({
@@ -94,6 +98,7 @@ const prepareSection = (obj) => ({
     city: obj.city,
     state: obj.state,
     zipcode: obj.cep,
+    company_nature: obj.company_nature,
   },
 });
 


### PR DESCRIPTION
- Adiciona testes e modelo do código e natureza jurídica da empresa no _backend_.
- Adiciona um novo componente genérico de entrada do formulário de texto e número, `PairOfNumberAndText`.
- Adiciona a propriedade de _placeholder_ no componente `MaskInput`.
- Adiciona nova seção no formulário de atualização do _frontend_, que contém informações sobre o novo campo.