### PR TITLE
Fix partners not rendering in CSV of companies updates

### DIFF
--- a/backend/app/models/company_update_request.rb
+++ b/backend/app/models/company_update_request.rb
@@ -8,14 +8,14 @@ class CompanyUpdateRequest
   field :timestamp, type: Time
   field :delivered, type: Boolean, default: false
 
-  embeds_one :company_data
-  embeds_one :about_company
-  embeds_one :incubation
-  embeds_one :dna_usp_stamp
-  embeds_many :partners ## [nil] * 29 + 5 + 5 + 20
-  embeds_one :investment ##   [nil] * 61 + 8
-  embeds_one :revenue ## [nil] * 69 + 1
-  embeds_one :staff ## [nil] * 58 + 3
+  embeds_one :company_data ## [nil] * 1 + 12 + [nil] * 61 + 4
+  embeds_one :about_company ## [nil] * 13 + 11
+  embeds_one :incubation ## [nil] * 24 + 2
+  embeds_one :dna_usp_stamp ## [nil] * 26 + 6
+  embeds_many :partners ## [nil] * 32 + 5 + 5 + 20
+  embeds_one :investment ##   [nil] * 62 + 8
+  embeds_one :revenue ## [nil] * 70 + 1
+  embeds_one :staff ## [nil] * 71 + 3
 
   def self.csv_headers
     subsection_classes = [
@@ -30,7 +30,6 @@ class CompanyUpdateRequest
     ]
 
     headers = merge([['Carimbo de data']] + subsection_classes.map { |cls| cls.send :csv_headers })
-    Rails.logger.debug headers
     headers
   end
 
@@ -38,6 +37,7 @@ class CompanyUpdateRequest
     CSV.generate(headers: true) do |csv|
       csv << csv_headers
       all.each do |cur|
+        partner_data = cur.partners.map(&:prepare_to_csv).flatten
         csv << merge([
                        [cur.timestamp],
                        cur.dna_usp_stamp.prepare_to_csv,
@@ -47,14 +47,14 @@ class CompanyUpdateRequest
                        cur.revenue.prepare_to_csv,
                        cur.incubation.prepare_to_csv,
                        cur.staff.prepare_to_csv,
-                       cur.partners.map(&:prepare_to_csv)
+                       partner_data,
                      ])
       end
     end
   end
 
   def self.merge(sections)
-    base = [nil] * 91
+    base = [nil] * 78
     base.each_with_index do |_b, i|
       sections.each do |sec|
         base[i] = base[i] || sec[i]

--- a/backend/app/models/company_update_request.rb
+++ b/backend/app/models/company_update_request.rb
@@ -29,8 +29,7 @@ class CompanyUpdateRequest
       Partner
     ]
 
-    headers = merge([['Carimbo de data']] + subsection_classes.map { |cls| cls.send :csv_headers })
-    headers
+    merge([['Carimbo de data']] + subsection_classes.map { |cls| cls.send :csv_headers })
   end
 
   def self.to_csv
@@ -47,7 +46,7 @@ class CompanyUpdateRequest
                        cur.revenue.prepare_to_csv,
                        cur.incubation.prepare_to_csv,
                        cur.staff.prepare_to_csv,
-                       partner_data,
+                       partner_data
                      ])
       end
     end

--- a/backend/app/models/dna_usp_stamp.rb
+++ b/backend/app/models/dna_usp_stamp.rb
@@ -63,7 +63,7 @@ class DnaUspStamp
 
   # rubocop:disable Lint/IneffectiveAccessModifier
   def self.row_offset
-    [nil] * 27
+    [nil] * 26
   end
   # rubocop:enable Lint/IneffectiveAccessModifier
 

--- a/backend/app/models/incubation.rb
+++ b/backend/app/models/incubation.rb
@@ -61,6 +61,6 @@ class Incubation
   end
 
   def self.row_offset
-    [nil] * 18
+    [nil] * 24
   end
 end

--- a/backend/app/models/investment.rb
+++ b/backend/app/models/investment.rb
@@ -68,7 +68,7 @@ class Investment
 
   # rubocop:disable Lint/IneffectiveAccessModifier
   def self.row_offset
-    [nil] * 65
+    [nil] * 62
   end
 
   # rubocop:enable Lint/IneffectiveAccessModifier

--- a/backend/app/models/partner.rb
+++ b/backend/app/models/partner.rb
@@ -39,35 +39,31 @@ class Partner
   end
 
   def prepare_to_csv
-    base = offset + [
+    base = [
       name,
       nusp,
       bond,
-      unity_to_csv
+      unity_to_csv,
+      nil
     ]
 
     return base if index > 1
 
-    base + [
+    Partner.row_offset + base + [
       email,
-      phone
+      phone,
+      nil,
+      nil,
+      nil
     ]
   end
 
-  def offset
-    jump = index > 1 ? [nil] * 10 : []
-
-    skip = index > 2 ? [nil] * 5 * (index - 2) : []
-
-    Partner.row_offset + jump + skip
+  def self.row_offset
+    [nil] * 32
   end
 
   def unity_to_csv
     bond.eql?('Nenhum') ? '' : unity
-  end
-
-  def self.row_offset
-    [nil] * 33
   end
 
   def self.csv_headers

--- a/backend/app/models/revenue.rb
+++ b/backend/app/models/revenue.rb
@@ -29,6 +29,6 @@ class Revenue
   end
 
   def self.row_offset
-    [nil] * 73
+    [nil] * 70
   end
 end

--- a/backend/app/models/staff.rb
+++ b/backend/app/models/staff.rb
@@ -54,6 +54,6 @@ class Staff
   end
 
   def self.row_offset
-    [nil] * 62
+    [nil] * 71
   end
 end

--- a/backend/spec/models/dna_usp_stamp_spec.rb
+++ b/backend/spec/models/dna_usp_stamp_spec.rb
@@ -63,7 +63,7 @@ RSpec.describe DnaUspStamp, type: :model do
 
   context 'with CSV preparation' do
     it 'prepares to CSV correctly' do
-      handmade = [nil] * 27 + [
+      handmade = [nil] * 26 + [
         attrs[:wants],
         attrs[:email],
         attrs[:name],

--- a/backend/spec/models/incubation_spec.rb
+++ b/backend/spec/models/incubation_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe Incubation, type: :model do
 
   context 'with CSV preparation' do
     let :handmade do
-      [nil] * 18 + [
+      [nil] * 24 + [
         attrs[:was_incubated],
         attrs[:ecosystem]
       ]

--- a/backend/spec/models/investment_spec.rb
+++ b/backend/spec/models/investment_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Investment, type: :model do
 
   context 'with CSV parsing' do
     let :handmade do
-      [nil] * 65 + [
+      [nil] * 62 + [
         'Sim',
         nil,
         attrs[:own],

--- a/backend/spec/models/partner_spec.rb
+++ b/backend/spec/models/partner_spec.rb
@@ -73,22 +73,27 @@ RSpec.describe Partner, type: :model do
 
   context 'with CSV preparation' do
     let :first_handmade do
-      [nil] * 33 + [
+      [nil] * 32 + [
         attrs[:name],
         attrs[:nusp],
         attrs[:bond],
         attrs[:unity],
+        nil,
         attrs[:email],
-        attrs[:phone]
+        attrs[:phone],
+        nil,
+        nil,
+        nil
       ]
     end
 
     let :fifth_handmade do
-      [nil] * 58 + [
+      [
         attrs[:name],
         attrs[:nusp],
         attrs[:bond],
-        attrs[:unity]
+        attrs[:unity],
+        nil
       ]
     end
 

--- a/backend/spec/models/revenue_spec.rb
+++ b/backend/spec/models/revenue_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Revenue, type: :model do
 
   context 'with CSV parsing' do
     let :handmade do
-      [nil] * 73 + [
+      [nil] * 70 + [
         attrs[:last_year]
       ]
     end

--- a/backend/spec/models/staff_spec.rb
+++ b/backend/spec/models/staff_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Staff, type: :model do
 
   context 'with CSV preparation' do
     let :handmade do
-      [nil] * 62 + [
+      [nil] * 71 + [
         attrs[:number_of_CLT_employees],
         attrs[:number_of_PJ_colaborators],
         attrs[:number_of_interns]


### PR DESCRIPTION
### Problema a ser corrigido

O `map` gera um array de valores de parceiros, que precisa ser mesclado para que esses dados sejam passados corretamente para as colunas do CSV. Caso contrário, a planilha recebe listas para serem registradas, no lugar dos dados de cada sócio. Para resolver o problema, essa mesclagem foi realizada, nesse _pull-request_, com o método `flatten`, de modo que a primeira entrada de sócio contém o _offset_ necessário para pular os demais campos da planilha e as demais entradas são mescladas em conjunto conforme a existência de novos sócios.

### Correções

- Corrige múltiplas posições de valores `nil` para evitar a sobrescrita de campos de sócios, explicitando esses valores no arquivo `backend/app/models/company_update_request.rb`.
- Corrige problema do `map`, realizando a mesclagem do _array_ de sócios e passando as entradas de forma correta ao CSV.
- Corrige testes automatizados de construção do CSV para adequação à mudança dos _offsets_.