### PR TITLE
Fix logo save with external link problem

### DIFF
--- a/backend/app/models/about_company.rb
+++ b/backend/app/models/about_company.rb
@@ -116,6 +116,8 @@ class AboutCompany
   # rubocop:enable Lint/IneffectiveAccessModifier
 
   def save_logo_to_public(logo, base_url)
+    return logo if logo.start_with?('http')
+
     FileUtils.mv(
       Rails.root.join('tmp', 'uploads', 'logos', logo),
       Rails.root.join('public', 'uploads', 'logos', logo)


### PR DESCRIPTION
Quando a logo é um link externo e não são realizadas mudanças, o _backend_ tenta mover algum arquivo que tem o nome desse link completo, resultando em um erro. Este _pull-request_ adiciona um condicional para, se caso a logo for um link externo, apenas retornar esse link e não realizar o _move_.