### PR TITLE
Add nusp validation

### DIFF
--- a/backend/app/models/partner.rb
+++ b/backend/app/models/partner.rb
@@ -21,6 +21,15 @@ class Partner
 
   validate :known_bonds?
 
+  validate :valid_nusp?
+  validate :known_bonds?
+ 
+  def valid_nusp?
+    is_valid = nusp.match?(/\A\d+\z/) || nusp.empty?
+    errors.add(:nusp, 'deve ser um número válido') unless is_valid
+  end
+
+
   def known_bonds?
     bonds = [
       'Aluno ou ex-aluno (graduação)',

--- a/backend/app/models/partner.rb
+++ b/backend/app/models/partner.rb
@@ -19,8 +19,6 @@ class Partner
   validates :unity, inclusion: all_unities + ['']
   validates :phone, phones: true
 
-  validate :known_bonds?
-
   validate :valid_nusp?
   validate :known_bonds?
  

--- a/backend/app/models/partner.rb
+++ b/backend/app/models/partner.rb
@@ -21,12 +21,11 @@ class Partner
 
   validate :valid_nusp?
   validate :known_bonds?
- 
+
   def valid_nusp?
     is_valid = nusp.match?(/\A\d+\z/) || nusp.empty?
     errors.add(:nusp, 'deve ser um número válido') unless is_valid
   end
-
 
   def known_bonds?
     bonds = [

--- a/backend/spec/models/partner_spec.rb
+++ b/backend/spec/models/partner_spec.rb
@@ -24,6 +24,12 @@ RSpec.describe Partner, type: :model do
       end
     end
 
+
+    it 'on invalid nusp format' do
+      attrs[:nusp] = 'invalid_nusp'
+      expect(described_class.new(attrs)).to be_invalid
+    end
+
     it 'on name being too short' do
       attrs[:name] = ''
       expect(described_class.new(attrs)).to be_invalid

--- a/backend/spec/models/partner_spec.rb
+++ b/backend/spec/models/partner_spec.rb
@@ -24,7 +24,6 @@ RSpec.describe Partner, type: :model do
       end
     end
 
-
     it 'on invalid nusp format' do
       attrs[:nusp] = 'invalid_nusp'
       expect(described_class.new(attrs)).to be_invalid


### PR DESCRIPTION
In the company update forms, there was an error that allowed a name to be entered in place of a NUSP, this field must be composed only by numerals. This PR is intended to correct this issue and ensure that such a possibility is no longer permitted.