### PR TITLE
Chore/show incubators names

### DIFF
--- a/backend/app/models/incubation.rb
+++ b/backend/app/models/incubation.rb
@@ -4,7 +4,7 @@ class Incubation
   include Mongoid::Document
 
   field :was_incubated, type: String
-  field :ecosystem, type: String
+  field :ecosystems, type: String
 
   embedded_in :company_update_request, inverse_of: :incubation
 
@@ -14,12 +14,12 @@ class Incubation
 
   def both_negative?
     was_incubated.eql?('Não') &&
-      (ecosystem.nil? || ecosystem.eql?('') || ecosystem.eql?('Direto para o Mercado'))
+      (ecosystems.nil? || ecosystems.eql?('') || ecosystems.eql?('Direto para o Mercado'))
   end
 
   def both_positive?
-    !was_incubated.eql?('Não') && !ecosystem.nil? && !ecosystem.eql?('') &&
-      !ecosystem.eql?('Direto para o Mercado')
+    !was_incubated.eql?('Não') && !ecosystems.nil? && !ecosystems.eql?('') &&
+      !ecosystems.eql?('Direto para o Mercado')
   end
 
   def consistent_pair?
@@ -27,7 +27,7 @@ class Incubation
 
     is_valid = both_negative? || both_positive?
 
-    errors.add(:ecosystem) unless is_valid
+    errors.add(:ecosystems) unless is_valid
   end
 
   def expected_was_incubated?
@@ -56,7 +56,7 @@ class Incubation
   def prepare_to_csv
     Incubation.row_offset + [
       was_incubated,
-      ecosystem
+      ecosystems
     ]
   end
 

--- a/backend/spec/models/incubation_spec.rb
+++ b/backend/spec/models/incubation_spec.rb
@@ -6,27 +6,27 @@ RSpec.describe Incubation, type: :model do
   let :attrs do
     {
       was_incubated: 'Sim. A empresa já está graduada',
-      ecosystem: 'Porto Digital'
+      ecosystems: 'Porto Digital'
     }
   end
 
   context 'without validation problems' do
     it 'works when was not incubated' do
       attrs[:was_incubated] = 'Não'
-      attrs[:ecosystem] = 'Direto para o Mercado'
+      attrs[:ecosystems] = 'Direto para o Mercado'
 
       expect(described_class.new(attrs)).to be_valid
     end
 
-    it 'works when no ecosystem is provided' do
+    it 'works when no ecosystems is provided' do
       attrs[:was_incubated] = 'Não'
-      attrs.delete :ecosystem
+      attrs.delete :ecosystems
       expect(described_class.new(attrs)).to be_valid
     end
 
-    it 'works when empty ecosystem is provided' do
+    it 'works when empty ecosystems is provided' do
       attrs[:was_incubated] = 'Não'
-      attrs[:ecosystem] = ''
+      attrs[:ecosystems] = ''
       expect(described_class.new(attrs)).to be_valid
     end
   end
@@ -42,15 +42,15 @@ RSpec.describe Incubation, type: :model do
       expect(described_class.new(attrs)).to be_invalid
     end
 
-    it 'on inconsistent ecosystem based on being incubated' do
+    it 'on inconsistent ecosystems based on being incubated' do
       attrs[:was_incubated] = 'Sim. A empresa está incubada'
-      attrs[:ecosystem] = 'Direto para o Mercado'
+      attrs[:ecosystems] = 'Direto para o Mercado'
       expect(described_class.new(attrs)).to be_invalid
     end
 
-    it 'on inconsistent incubated based on ecosystem' do
+    it 'on inconsistent incubated based on ecosystems' do
       attrs[:was_incubated] = 'Não'
-      attrs[:ecosystem] = 'Porto Digital'
+      attrs[:ecosystems] = 'Porto Digital'
       expect(described_class.new(attrs)).to be_invalid
     end
   end
@@ -59,7 +59,7 @@ RSpec.describe Incubation, type: :model do
     let :handmade do
       [nil] * 24 + [
         attrs[:was_incubated],
-        attrs[:ecosystem]
+        attrs[:ecosystems]
       ]
     end
 

--- a/backend/spec/requests/company_updates_spec.rb
+++ b/backend/spec/requests/company_updates_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe 'CompanyUpdates', type: :request do
       },
       incubation: {
         was_incubated: 'Não',
-        ecosystem: 'Direto para o Mercado'
+        ecosystems: 'Direto para o Mercado'
       },
       partners: [
         {

--- a/frontend/components/CompanyForms/companyStep/Incubator.vue
+++ b/frontend/components/CompanyForms/companyStep/Incubator.vue
@@ -9,7 +9,7 @@
       label=""
       @input="setIncubated"
     />
-
+    {{ ecosystems }}
     <div v-if="!disabledIncubatorsSelect">
       <h2 class="text-h6 mt-6 font-weight-regular">
         Se sim, em qual incubadora ou Parque Tecnológico? *
@@ -20,6 +20,7 @@
         :disabled="disabledIncubatorsSelect"
         label=""
         @input="setDefaultIncubators"
+        :multipleOption="true"
       />
       <div class="mt-5 text-h6 font-weight-regular">
         Em caso de outros, digite abaixo:
@@ -57,7 +58,7 @@ export default {
       "ESALQTec - Incubadora de Empresas Agrozootécnicas de Piracicaba",
       "HABITs - Habitat de Inovação Tecnológica e Social/Incubadora-Escola",
       "ParqTec - Fundação Parque Tecnológico de São Carlos",
-      "Supera - Parque de Inovação e Tecnologia de Ribeirão Preto",
+      "Supera - Parque de Inovação e Tecnologia de Ribeirão Preto"
     ],
   }),
   computed: {
@@ -73,10 +74,26 @@ export default {
       return false;
     },
     defaultIncubators() {
-      return this.incubadoras.includes(this.ecosystems) ? this.ecosystems : "";
+      let matchingDefaultIncubators = [];
+
+      for (let ecosystem of this.ecosystems) {
+        if (this.incubadoras.includes(ecosystem)) {
+          matchingDefaultIncubators.push(ecosystem);
+        }
+      }
+
+      return matchingDefaultIncubators;
     },
     otherIncubator() {
-      return this.incubadoras.includes(this.ecosystems) ? "" : this.ecosystems;
+      // let matchingOtherIncubators = [];
+
+      // for (let ecosystem of this.ecosystems) {
+      //   if (!this.incubadoras.includes(ecosystem)) {
+      //     matchingOtherIncubators.push(ecosystem);
+      //   }
+      // }
+      console.log("oi");
+      //return matchingOtherIncubators;
     },
   },
   methods: {

--- a/frontend/store/company_forms/incubation.js
+++ b/frontend/store/company_forms/incubation.js
@@ -1,11 +1,11 @@
 const state = () => ({
   incubated: "",
-  ecosystem: '',
+  ecosystems: '',
 });
 
 const getters = {
   incubated: (s) => s.incubated,
-  ecosystems: (s) => s.ecosystem,
+  ecosystems: (s) => s.ecosystems,
 };
 
 const mutations = {
@@ -17,13 +17,13 @@ const actions = {
   setIncubated: ({ commit }, value) =>
     commit("setFormField", { key: "incubated", value }),
   setEcosystems: ({ commit }, value) =>
-    commit("setFormField", { key: "ecosystem", value }),
+    commit("setFormField", { key: "ecosystems", value }),
 };
 
 const prepareSection = (obj) => ({
   incubation: {
     was_incubated: obj.incubated,
-    ecosystem: obj.ecosystems
+    ecosystems: obj.ecosystems
   },
 });
 


### PR DESCRIPTION
Foram feitas mudanças no front e no back de modo que, se a empresa em questão for incubada, suas incubadoras são exibidas no formulário (o que não estava ocorrendo antes). 