### PR TITLE
Fix catalog 500 error

### DIFF
--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/models/CompanyModel.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/models/CompanyModel.kt
@@ -5,14 +5,14 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class CompanyModel(
-    val active: Boolean,
+    val active: Boolean? = true,
     val address: CompanyAddressModel,
-    val allowed: Boolean,
+    val allowed: Boolean? = true,
     val classification: CompanyClassificationModel,
     val cnae: String,
     val cnpj: String,
     val companySize: Set<String>,
-    val corporateName: String,
+    val corporateName: String? = "",
     val description: String,
     val ecosystems: Set<String>,
     val emails: Set<String>,


### PR DESCRIPTION
When company data is fetched by Ruby on Rails, some fields that are required do not generate an error. In this case, persistence model conflicts with required company fields and gives 500 error.

This solution adds standard values to some fields in Company, which solves the problem while using Ruby on Rails Company fetch. We can revert this PR when Kotlin fetch start sending verification e-mails too.