### PR TITLE
Remove localdatetime to avoid pdi serializer error

### DIFF
--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/PDI.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/PDI.kt
@@ -1,32 +1,5 @@
 package br.usp.inovacao.hubusp.server.catalog
 
-import kotlinx.serialization.Contextual
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
-import java.sql.Timestamp
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
-@Serializer(forClass = LocalDateTime::class)
-object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
-    private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
-
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
-
-    override fun serialize(encoder: Encoder, value: LocalDateTime) {
-        encoder.encodeString(value.format(formatter))
-    }
-
-    override fun deserialize(decoder: Decoder): LocalDateTime {
-        return LocalDateTime.parse(decoder.decodeString(), formatter)
-    }
-}
-
 @kotlinx.serialization.Serializable
 data class PDI(
     val category: String,
@@ -39,5 +12,4 @@ data class PDI(
     val phone: String,
     val description: String,
     val tags: Set<String>,
-    @Contextual val timestamp: LocalDateTime
 )

--- a/server/curatorship/src/main/kotlin/br/usp/inovacao/hubusp/curatorship/sheets/PDI.kt
+++ b/server/curatorship/src/main/kotlin/br/usp/inovacao/hubusp/curatorship/sheets/PDI.kt
@@ -1,36 +1,13 @@
 package br.usp.inovacao.hubusp.curatorship.sheets
 
-import kotlinx.serialization.Contextual
-import kotlinx.serialization.KSerializer
-import kotlinx.serialization.Serializer
-import kotlinx.serialization.descriptors.PrimitiveKind
-import kotlinx.serialization.descriptors.PrimitiveSerialDescriptor
-import kotlinx.serialization.descriptors.SerialDescriptor
-import kotlinx.serialization.encoding.Decoder
-import kotlinx.serialization.encoding.Encoder
+import kotlinx.serialization.Serializable
 import org.valiktor.ConstraintViolationException
 import org.valiktor.functions.*
 import org.valiktor.i18n.mapToMessage
 import org.valiktor.validate
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
 
-@Serializer(forClass = LocalDateTime::class)
-object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
-    private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
-
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
-
-    override fun serialize(encoder: Encoder, value: LocalDateTime) {
-        encoder.encodeString(value.format(formatter))
-    }
-
-    override fun deserialize(decoder: Decoder): LocalDateTime {
-        return LocalDateTime.parse(decoder.decodeString(), formatter)
-    }
-}
-
-@kotlinx.serialization.Serializable
+@OptIn(kotlinx.serialization.ExperimentalSerializationApi::class)
+@Serializable
 data class PDI(
     val category: String?,
     val name: String?,
@@ -42,7 +19,6 @@ data class PDI(
     val description: String?,
     val site: String?,
     val keywords: Set<String>?,
-    @Contextual val timestamp: LocalDateTime
 ) {
     companion object {
         val categories = listOf("CEPID", "EMBRAPII", "INCT", "NAP", "Centro de Pesquisa em Engenharia")
@@ -58,7 +34,6 @@ data class PDI(
             phone = row[8],
             description = row[11],
             keywords = row[14]?.split(";")?.toSet(),
-            timestamp = LocalDateTime.now()
         )
     }
 

--- a/server/curatorship/src/test/kotlin/br/usp/inovacao/hubusp/curatorship/sheets/PDITestHelp.kt
+++ b/server/curatorship/src/test/kotlin/br/usp/inovacao/hubusp/curatorship/sheets/PDITestHelp.kt
@@ -1,7 +1,5 @@
 package br.usp.inovacao.hubusp.curatorship.sheets
 
-import java.time.LocalDateTime
-
 fun PDI.toRow(): List<String?> = listOf(
     category,
     name,
@@ -17,8 +15,7 @@ fun PDI.toRow(): List<String?> = listOf(
     description,
     null,
     null,
-    keywords?.joinToString(";"),
-    timestamp.toString()
+    keywords?.joinToString(";")
 )
 
 class PDITestHelp {
@@ -33,8 +30,7 @@ class PDITestHelp {
             email = null,
             description = "lorem ipsum",
             site = null,
-            keywords = setOf("foo", "baz"),
-            timestamp = LocalDateTime.now()
+            keywords = setOf("foo", "baz")
         )
 
         fun validRowAndInvalidRow(): List<List<String?>> {

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogPDIRepositoryImpl.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogPDIRepositoryImpl.kt
@@ -10,8 +10,16 @@ import org.litote.kmongo.find
 import org.litote.kmongo.getCollection
 
 fun PDIModel.toCatalogPDI(): PDI = PDI(
-    category, name, campus, unity, coordinator,
-    site, email, phone, description, tags, timestamp,
+    category = this.category,
+    name = this.name,
+    campus = this.campus,
+    unity = this.unity,
+    coordinator = this.coordinator,
+    site = this.site,
+    email = this.email,
+    phone = this.phone,
+    description = this.description,
+    tags = this.tags
 )
 
 class CatalogPDIRepositoryImpl(

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/curatorship/PDIRepositoryImpl.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/curatorship/PDIRepositoryImpl.kt
@@ -31,8 +31,7 @@ class PDIRepositoryImpl(
            email = pdi.email ?: "",
            phone = pdi.phone ?: "",
            description = pdi.description!!,
-           tags = pdi.keywords!!,
-           timestamp = pdi.timestamp
+           tags = pdi.keywords!!
         )
 
         pdiCollection.insertOne(pdiModel)

--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/models/PDIModel.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/models/PDIModel.kt
@@ -9,24 +9,6 @@ import kotlinx.serialization.descriptors.SerialDescriptor
 import kotlinx.serialization.encoding.Decoder
 import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.Contextual
-import java.sql.Timestamp
-import java.time.LocalDateTime
-import java.time.format.DateTimeFormatter
-
-@Serializer(forClass = LocalDateTime::class)
-object LocalDateTimeSerializer : KSerializer<LocalDateTime> {
-    private val formatter: DateTimeFormatter = DateTimeFormatter.ISO_LOCAL_DATE_TIME
-
-    override val descriptor: SerialDescriptor = PrimitiveSerialDescriptor("LocalDateTime", PrimitiveKind.STRING)
-
-    override fun serialize(encoder: Encoder, value: LocalDateTime) {
-        encoder.encodeString(value.format(formatter))
-    }
-
-    override fun deserialize(decoder: Decoder): LocalDateTime {
-        return LocalDateTime.parse(decoder.decodeString(), formatter)
-    }
-}
 
 @Serializable
 data class PDIModel(
@@ -40,5 +22,4 @@ data class PDIModel(
     val phone: String,
     val description: String,
     val tags: Set<String>,
-    @Contextual val timestamp: LocalDateTime,
 )

--- a/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogPDIRepositoryImplTest.kt
+++ b/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogPDIRepositoryImplTest.kt
@@ -5,7 +5,6 @@ import br.usp.inovacao.hubusp.server.persistence.models.PDIModel
 import com.mongodb.client.MongoDatabase
 import org.litote.kmongo.deleteMany
 import org.litote.kmongo.getCollection
-import java.time.LocalDateTime
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -134,8 +133,7 @@ class CatalogPDIRepositoryImplTest {
             email = "dimas@fmrp.usp.br",
             phone = "(16) 21019300",
             description = "Seu objetivo é desenvolver pesquisas para entender a biologia das células-tronco, bem como em desenvolver novas tecnologias para seu uso no tratamento de doenças. O grupo de pesquisadores envolve médicos, biólogos, profissionais biomédicos, farmacêuticos e veterinários, entre outros.",
-            tags = setOf("Célula-tronco", "Ensaios clínicos"),
-            timestamp = LocalDateTime.now()
+            tags = setOf("Célula-tronco", "Ensaios clínicos")
         ),
         PDIModel (
             category = "Centro de Pesquisa em Engenharia",
@@ -147,8 +145,7 @@ class CatalogPDIRepositoryImplTest {
             email = "c4ai@usp.br",
             phone = "n/d",
             description = "multidispositivo O Centro de Inteligência Artificial (Center for Artificial Intelligence - C4AI) tem o compromisso de desenvolver pesquisas no estado da arte em Inteligência Artificial (IA), explorando tanto aspectos básicos quanto aplicados nesta área. Com suporte da IBM e da Fundação de Amparo à Pesquisa do Estado de São Paulo (FAPESP), o C4AI também desenvolve estudos sobre o impacto social e econômico da IA e conduz atividades de disseminação de conhecimento e transferência de tecnologia, procurando formas de melhorar a qualidade de vida humana e incrementar diversidade e inclusão. O C4AI considera que o próximo nível de desempenho em IA só poderá ser alcançado enfatizando a combinação de aprendizado de máquina, tomada de decisão, representação de conhecimento e raciocínio, e incrementando a colaboração entre essas áreas e suas aplicações. A conexão entre as tópicos básicos de pesquisa e áreas de aplicação de IA funciona nos dois sentidos: os tópicos básicos permitem a abordagem de problemas de grande escala nas áreas de aplicação selecionadas, e por outro lado são alimentados pelos desafios de escala nessas áreas de aplicação.",
-            tags = setOf("IA", "Dados", "Códigos abertos"),
-            timestamp = LocalDateTime.now()
+            tags = setOf("IA", "Dados", "Códigos abertos")
         )
     )
 }

--- a/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/journey/JourneyRepositoryImplTest.kt
+++ b/server/persistence/src/test/kotlin/br/usp/inovacao/hubusp/server/persistence/journey/JourneyRepositoryImplTest.kt
@@ -9,7 +9,6 @@ import br.usp.inovacao.hubusp.server.persistence.models.*
 import com.mongodb.client.MongoDatabase
 import org.litote.kmongo.deleteMany
 import org.litote.kmongo.getCollection
-import java.time.LocalDateTime
 import kotlin.test.BeforeTest
 import kotlin.test.Test
 import kotlin.test.assertEquals
@@ -148,8 +147,7 @@ internal class JourneyRepositoryImplTest {
             email = "",
             phone = "",
             description = "",
-            tags = emptySet(),
-            timestamp = LocalDateTime.now()
+            tags = emptySet()
         ),
         PDIModel(
             category = "INCT",
@@ -161,8 +159,7 @@ internal class JourneyRepositoryImplTest {
             email = "",
             phone = "",
             description = "",
-            tags = emptySet(),
-            timestamp = LocalDateTime.now()
+            tags = emptySet()
         )
     )
 


### PR DESCRIPTION
The Kotlin Custom Serializer for LocalDateTime was not working properly, interfering with the PDI catalog Data showing.