### PR TITLE
Remove empty company cities on companies filter

### DIFF
--- a/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogCompanyRepositoryImpl.kt
+++ b/server/persistence/src/main/kotlin/br/usp/inovacao/hubusp/server/persistence/CatalogCompanyRepositoryImpl.kt
@@ -11,48 +11,43 @@ import org.litote.kmongo.*
 
 @Serializable
 data class Ecosystem(
-    val name: String,
+        val name: String,
 )
 
-@Serializable
-data class City (
-    val name: String
-)
+@Serializable data class City(val name: String)
 
-fun CompanyClassificationModel.toCatalogClassification(): Classification = Classification(
-    major = this.major,
-    minor = this.minor
-)
+fun CompanyClassificationModel.toCatalogClassification(): Classification =
+        Classification(major = this.major, minor = this.minor)
 
-fun CompanyAddressModel.toCatalogAddress(): Address = Address(
-    cep = this.cep,
-    city = this.city,
-    neighborhood = this.neighborhood,
-    state = this.state,
-    venue = this.venue
-)
+fun CompanyAddressModel.toCatalogAddress(): Address =
+        Address(
+                cep = this.cep,
+                city = this.city,
+                neighborhood = this.neighborhood,
+                state = this.state,
+                venue = this.venue
+        )
 
-fun CompanyModel.toCatalogCompany(): Company = Company(
-    address = this.address.toCatalogAddress(),
-    classification = this.classification.toCatalogClassification(),
-    cnae = this.cnae,
-    companySize = this.companySize,
-    description = this.description,
-    ecosystems = this.ecosystems,
-    emails = this.emails,
-    incubated = this.incubated,
-    logo = this.logo,
-    name = this.name,
-    phones = this.phones,
-    services = this.services,
-    technologies = this.technologies,
-    unities = this.partners.map { it.unity }.toSet(),
-    url = this.url
-)
+fun CompanyModel.toCatalogCompany(): Company =
+        Company(
+                address = this.address.toCatalogAddress(),
+                classification = this.classification.toCatalogClassification(),
+                cnae = this.cnae,
+                companySize = this.companySize,
+                description = this.description,
+                ecosystems = this.ecosystems,
+                emails = this.emails,
+                incubated = this.incubated,
+                logo = this.logo,
+                name = this.name,
+                phones = this.phones,
+                services = this.services,
+                technologies = this.technologies,
+                unities = this.partners.map { it.unity }.toSet(),
+                url = this.url
+        )
 
-class CatalogCompanyRepositoryImpl(
-    db: MongoDatabase
-) : CompanyRepository {
+class CatalogCompanyRepositoryImpl(db: MongoDatabase) : CompanyRepository {
     private val companyCollection: MongoCollection<CompanyModel>
 
     init {
@@ -62,34 +57,34 @@ class CatalogCompanyRepositoryImpl(
     override fun filter(params: CompanySearchParams): Set<Company> {
         val filter = params.toCollectionFilter()
 
-        return companyCollection
-            .find(filter)
-            .map { it.toCatalogCompany() }
-            .toSet()
+        return companyCollection.find(filter).map { it.toCatalogCompany() }.toSet()
     }
 
-    override fun getEcosystems(): Set<String> = companyCollection
-        .aggregate<Ecosystem>(
-            "[{ \$project: { _id: 0, ecosystems: 1 } }," +
-            "{ \$unwind: { path: '\$ecosystems' } }," +
-            "{ \$project: { ecosystems: { \$ltrim: { input: '\$ecosystems', chars: ' ' } } } }," +
-            "{ \$group: { _id: 'allEcos', name: { \$addToSet: '\$ecosystems' } } }," +
-            "{ \$project: { _id: 0, name: 1 } }," +
-            "{ \$unwind: { path: '\$name' } }," +
-            "{ \$sort: { name: 1 } }]"
-        )
-        .map { it.name }
-        .toSet()
+    override fun getEcosystems(): Set<String> =
+            companyCollection
+                    .aggregate<Ecosystem>(
+                            "[{ \$project: { _id: 0, ecosystems: 1 } }," +
+                                    "{ \$unwind: { path: '\$ecosystems' } }," +
+                                    "{ \$project: { ecosystems: { \$ltrim: { input: '\$ecosystems', chars: ' ' } } } }," +
+                                    "{ \$group: { _id: 'allEcos', name: { \$addToSet: '\$ecosystems' } } }," +
+                                    "{ \$project: { _id: 0, name: 1 } }," +
+                                    "{ \$unwind: { path: '\$name' } }," +
+                                    "{ \$sort: { name: 1 } }]"
+                    )
+                    .map { it.name }
+                    .toSet()
 
-    override fun getCities(): Set<String> = companyCollection
-        .aggregate<City>(
-            "[{ \$project: { _id: 0, city: '\$address.city' } }," +
-            "{ \$project: { city: { \$ltrim: { input: '\$city', chars: ' ' } } } }," +
-            "{ \$group: { _id: 'allCities', name: { \$addToSet: '\$city' } } }," +
-            "{ \$project: { _id: 0, name: 1 } }," +
-            "{ \$unwind: { path: '\$name' } }," +
-            "{ \$sort: { name: 1 } }]"
-        )
-        .map { it.name }
-        .toSet()
+    override fun getCities(): Set<String> =
+            companyCollection
+                    .aggregate<City>(
+                            "[{ \$project: { _id: 0, city: '\$address.city' } }," +
+                                    "{ \$project: { city: { \$ltrim: { input: '\$city', chars: ' ' } } } }," +
+                                    "{ \$group: { _id: 'allCities', name: { \$addToSet: '\$city' } } }," +
+                                    "{ \$project: { _id: 0, name: 1 } }," +
+                                    "{ \$unwind: { path: '\$name' } }," +
+                                    "{ \$sort: { name: 1 } }]"
+                    )
+                    .map { it.name }
+                    .filter { it.isNotBlank() }
+                    .toSet()
 }


### PR DESCRIPTION
The frontend had a bug, where empty city names was included on companies cities filter
![image](https://github.com/user-attachments/assets/67ab9a2f-26d4-467f-b6c7-11f4223376a7)

This PR solves the problem, removing all empty cities name from the get cities response

![image](https://github.com/user-attachments/assets/e7d6c8ec-2774-4690-8edd-6bd1a91a6f14)
