### PR TITLE
frontend/Dockerfile: Set NODE_ENV before 'yarn install'

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -36,12 +36,12 @@ CMD yarn dev
 
 FROM base AS production
 
+ENV NODE_ENV=production
+
 RUN yarn install
 
 COPY . ./
 
 RUN yarn build
-
-ENV NODE_ENV=production
 
 CMD yarn start


### PR DESCRIPTION
`NODE_ENV=production` should be set before `yarn install` to avoid installing dev dependencies in the production image
> Yarn will not install any package listed in devDependencies if the NODE_ENV environment variable is set to production
> https://classic.yarnpkg.com/en/docs/cli/install#toc-yarn-install-production-true-false

This is a draft because I need to check if the dependencies are right (that `aos` package in the dev deps looks a bit odd)