### PR TITLE
chore: Only run kotlin-ci if files under server/ were modified

### DIFF
--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -1,8 +1,12 @@
 name: kotlin-CI
 on:
   pull_request:
+    paths:
+      - 'server/**'
   push:
     branches: [master]
+    paths:
+      - 'server/**'
 
 jobs:
 


### PR DESCRIPTION
Currently, the kotlin-ci is running on **every PR** and **every push** to master (even if it's unrelated to the kotlin backend)

This PR modifies the `kotlin-ci` workflow to only run if files under `server/**` were modified.

> https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore

I don't think it's possible to test this without merging. I'll try to hotfix it if it breaks.