### PR TITLE
Change fetch to support service account

### DIFF
--- a/server/curatorship/build.gradle.kts
+++ b/server/curatorship/build.gradle.kts
@@ -34,6 +34,9 @@ dependencies {
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktor_version")
     implementation("com.typesafe:config:$typesafe_config_version")
     implementation("it.skrape:skrapeit:1.3.0-alpha.1")
+    implementation("com.google.auth:google-auth-library-oauth2-http:1.37.1")
+    implementation("com.google.api-client:google-api-client:2.7.2")
+    implementation("com.google.apis:google-api-services-sheets:v4-rev20250211-2.0.0")
     testImplementation("org.jetbrains.kotlin:kotlin-test-junit:$kotlin_version")
     testImplementation("io.mockk:mockk:$mockk_version")
 }

--- a/server/curatorship/src/main/kotlin/br/usp/inovacao/hubusp/curatorship/CliCommandTest.kt
+++ b/server/curatorship/src/main/kotlin/br/usp/inovacao/hubusp/curatorship/CliCommandTest.kt
@@ -8,11 +8,10 @@ class CliCommandTest {
     private val mailer: Mailer
 
     init {
-        val apiKey = Configuration.SHEETS_API_KEY
         val user = Configuration.EMAIL_USERNAME
         val password = Configuration.EMAIL_PASSWORD
 
-        reader = SpreadsheetReader(apiKey)
+        reader = SpreadsheetReader()
         mailer = Mailer(user, password)
     }
 

--- a/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshCompany.kt
+++ b/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshCompany.kt
@@ -14,7 +14,6 @@ class RefreshCompany : CliktCommand() {
     init {
         val user = Configuration.EMAIL_USERNAME
         val password = Configuration.EMAIL_PASSWORD
-        val apiKey = Configuration.SHEETS_API_KEY
 
         val protocol = Configuration.DATASOURCE_PROTOCOL
         val host = Configuration.DATASOURCE_HOST
@@ -24,7 +23,7 @@ class RefreshCompany : CliktCommand() {
         val db = configureDB(protocol, host, port, dbName)
         refreshCompany = br.usp.inovacao.hubusp.curatorship.sheets.RefreshCompany(
             mailer = Mailer(user, password),
-            spreadsheetReader = SpreadsheetReader(apiKey),
+            spreadsheetReader = SpreadsheetReader(),
             companyRepository = CompanyRepositoryImpl(db),
             companyErrorRepository = CompanyErrorRepositoryImpl(db)
         )

--- a/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshDiscipline.kt
+++ b/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshDiscipline.kt
@@ -14,7 +14,6 @@ class RefreshDiscipline : CliktCommand() {
     init {
         val user = Configuration.EMAIL_USERNAME
         val password = Configuration.EMAIL_PASSWORD
-        val apiKey = Configuration.SHEETS_API_KEY
 
         val protocol = Configuration.DATASOURCE_PROTOCOL
         val host = Configuration.DATASOURCE_HOST
@@ -24,7 +23,7 @@ class RefreshDiscipline : CliktCommand() {
         val db = configureDB(protocol, host, port, dbName)
         refreshDiscipline = br.usp.inovacao.hubusp.curatorship.sheets.RefreshDiscipline(
             mailer = Mailer(user, password),
-            spreadsheetReader = SpreadsheetReader(apiKey),
+            spreadsheetReader = SpreadsheetReader(),
             disciplineRepository = DisciplineRepositoryImpl(db),
             disciplineErrorRepository = DisciplineErrorRepositoryImpl(db)
         )

--- a/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshInitiative.kt
+++ b/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshInitiative.kt
@@ -14,7 +14,6 @@ class RefreshInitiative : CliktCommand() {
     init {
         val user = Configuration.EMAIL_USERNAME
         val password = Configuration.EMAIL_PASSWORD
-        val apiKey = Configuration.SHEETS_API_KEY
 
         val protocol = Configuration.DATASOURCE_PROTOCOL
         val host = Configuration.DATASOURCE_HOST
@@ -24,7 +23,7 @@ class RefreshInitiative : CliktCommand() {
         val db = configureDB(protocol, host, port, dbName)
         refreshInitiative = br.usp.inovacao.hubusp.curatorship.sheets.RefreshInitiative(
             mailer = Mailer(user, password),
-            spreadsheetReader = SpreadsheetReader(apiKey),
+            spreadsheetReader = SpreadsheetReader(),
             initiativeRepository = InitiativeRepositoryImpl(db),
             initiativeErrorRepository = InitiativeErrorRepositoryImpl(db)
         )

--- a/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshPDI.kt
+++ b/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshPDI.kt
@@ -14,7 +14,6 @@ class RefreshPDI : CliktCommand() {
     init {
         val user = Configuration.EMAIL_USERNAME
         val password = Configuration.EMAIL_PASSWORD
-        val apiKey = Configuration.SHEETS_API_KEY
 
         val protocol = Configuration.DATASOURCE_PROTOCOL
         val host = Configuration.DATASOURCE_HOST
@@ -24,7 +23,7 @@ class RefreshPDI : CliktCommand() {
         val db = configureDB(protocol, host, port, dbName)
         refreshPDI = br.usp.inovacao.hubusp.curatorship.sheets.RefreshPDI(
             mailer = Mailer(user, password),
-            spreadsheetReader = SpreadsheetReader(apiKey),
+            spreadsheetReader = SpreadsheetReader(),
             pdiRepository = PDIRepositoryImpl(db),
             pdiErrorRepository = PDIErrorRepositoryImpl(db)
         )

--- a/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshResearcher.kt
+++ b/server/hub-cli/src/main/kotlin/br/usp/inovacao/hubusp/server/cli/commands/curatorship/RefreshResearcher.kt
@@ -14,7 +14,6 @@ class RefreshResearcher : CliktCommand() {
     init {
         val user = Configuration.EMAIL_USERNAME
         val password = Configuration.EMAIL_PASSWORD
-        val apiKey = Configuration.SHEETS_API_KEY
 
         val protocol = Configuration.DATASOURCE_PROTOCOL
         val host = Configuration.DATASOURCE_HOST
@@ -24,7 +23,7 @@ class RefreshResearcher : CliktCommand() {
         val db = configureDB(protocol, host, port, dbName)
         refreshResearcher = br.usp.inovacao.hubusp.curatorship.sheets.RefreshResearcher(
             mailer = Mailer(user, password),
-            spreadsheetReader = SpreadsheetReader(apiKey),
+            spreadsheetReader = SpreadsheetReader(),
             researcherRepository = ResearcherRepositoryImpl(db),
             researcherErrorRepository = ResearcherErrorRepositoryImpl(db)
         )


### PR DESCRIPTION
Closes #280 

The application now uses a service account to fetch the spreadsheets instead of the previous apiKeys method, making it possible to access restricted spreadsheets, given permission to said account to read them.