### PR TITLE
server: Refresh Patent

### DIFF
--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Patent.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/Patent.kt
@@ -12,16 +12,16 @@ data class Patent(
     val status: String,
     val summary: String,
     val url: String? = null
-)
+) {
+    companion object {}
+}
 
 @kotlinx.serialization.Serializable
-data class DualClassification(
-    val primary: Area,
-    val secondary: Area? = null
-)
+data class DualClassification(val primary: Area, val secondary: Area? = null) {
+    companion object {}
+}
 
 @kotlinx.serialization.Serializable
-data class Area(
-    val cip: String,
-    val subarea: String
-)
+data class Area(val cip: String, val subarea: String) {
+    companion object {}
+}

--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/PatentRepository.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/PatentRepository.kt
@@ -1,6 +1,6 @@
 package br.usp.inovacao.hubusp.server.catalog
 
-interface PatentRepository {
+interface PatentRepository : OverwritableRepository<Patent> {
     /**
      * Filters Patents from the datasource
      *

--- a/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/RepositoryTraits.kt
+++ b/server/catalog/src/main/kotlin/br/usp/inovacao/hubusp/server/catalog/RepositoryTraits.kt
@@ -1,0 +1,51 @@
+package br.usp.inovacao.hubusp.server.catalog
+
+/**
+ * Repository that can be collected
+ *
+ * Requires enough memory to store the whole repository
+ *
+ * @param RecordModel Represents a valid record in the repository
+ * @param ValidationError Validation error returned for each invalid record
+ */
+interface CollectableRepository<RecordModel, ValidationError> {
+    fun collect(): Pair<Set<RecordModel>, List<ValidationError>>
+}
+
+/** Repository that can be dropped/cleared */
+interface ClearableRepository<RecordModel> {
+    fun clear()
+}
+
+/** Repository that can append records */
+interface AppendableRepository<RecordModel> {
+    fun append(record: RecordModel) {
+        this.appendAll(setOf(record))
+    }
+
+    fun appendAll(records: Set<RecordModel>)
+}
+
+/** Repository that can be completely overwritten */
+interface OverwritableRepository<RecordModel> :
+    ClearableRepository<RecordModel>, AppendableRepository<RecordModel> {
+    /** Overwrite repository with set of records */
+    fun overwriteAll(records: Set<RecordModel>) {
+        this.clear()
+        this.appendAll(records)
+    }
+
+    /** Overwrite repository with records from another repository */
+    fun <ValidationError> sync(
+        referenceRepository: CollectableRepository<RecordModel, ValidationError>
+    ): List<ValidationError> {
+        val (validRecords, errors) = referenceRepository.collect()
+        this.overwriteAll(validRecords)
+        return errors
+    }
+}
+
+/** Repository that can be searched with filters */
+interface SearchableRepository<RecordModel, Filter> {
+    fun search(filter: Filter): Set<RecordModel>
+}

--- a/server/curatorship/build.gradle.kts
+++ b/server/curatorship/build.gradle.kts
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation(project(":mailer"))
+    implementation(project(":catalog"))
 
     implementation("org.valiktor:valiktor-core:$valiktor_version")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:$coroutines_version")

--- a/server/curatorship/src/main/kotlin/br/usp/inovacao/hubusp/curatorship/sheets/PatentSheetsRepository.kt
+++ b/server/curatorship/src/main/kotlin/br/usp/inovacao/hubusp/curatorship/sheets/PatentSheetsRepository.kt
@@ -1,0 +1,121 @@
+package br.usp.inovacao.hubusp.curatorship.sheets
+
+import br.usp.inovacao.hubusp.server.catalog.Area
+import br.usp.inovacao.hubusp.server.catalog.CollectableRepository
+import br.usp.inovacao.hubusp.server.catalog.DualClassification
+import br.usp.inovacao.hubusp.server.catalog.Patent
+import kotlin.Result
+
+fun splitAndTrim(raw: String?, separator: Char): Set<String>? {
+    return raw?.split(separator)?.map { it.trim() }?.toSet()
+}
+
+fun Area.Companion.fromRow(row: List<String?>) =
+    try {
+        Result.success(
+            Area(
+                cip = row[0]!!,
+                subarea = row[1]!!,
+            ))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+fun DualClassification.Companion.fromRow(row: List<String?>) =
+    try {
+        Result.success(
+            DualClassification(
+                primary = Area.fromRow(row).getOrThrow(),
+                secondary = Area.fromRow(row).getOrNull()))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+// 0  Cip Principal (Classificação Internacional de Patente)
+// 1  Sub-Areas
+// 2  CIP secundario
+// 3  sub-area secundaria
+// 4  Número da Patente
+// 5  Title
+// 6  CIP (ipcs?)
+// 7  Application Year
+// 8  Depositante (owners)
+// 9  Inventor
+// 10 Abstract
+// 11 Países de Depósito
+// 12 STATUS concedia OU em analise
+// 13 Hiperlink
+// 14 Link extraido
+// 15 ID flyer
+fun Patent.Companion.fromRow(row: List<String?>) =
+    try {
+        Result.success(
+            Patent(
+                classification = DualClassification.fromRow(row).getOrThrow(),
+                countries_with_protection = row[11]!!.split("; ?".toRegex()).toSet(),
+                inventors = row[9]!!.split(" ?\\| ?".toRegex()).toSet(),
+                ipcs = row[6]!!.split(" ?\\| ?".toRegex()).toSet(),
+                name = row[5]!!,
+                owners = row[8]!!.split(" ?\\| ?".toRegex()).toSet(),
+                photo =
+                    when (val id = row[15]) {
+                        "N/D" -> null
+                        else -> "https://drive.google.com/uc?export=view&id=$id"
+                    },
+                status = row[12]!!,
+                summary = row[10]!!,
+                url =
+                    when (val url = row[14]) {
+                        "N/D" -> null
+                        else -> url
+                    }))
+    } catch (e: Exception) {
+        Result.failure(e)
+    }
+
+sealed class PatentSheetsError {
+    class ValidationError(val messages: List<String>, val spreadsheetLineNumber: Int)
+
+    class UniquenessError(val messages: List<String>, val spreadsheetLineNumber: Int)
+
+    class UnknownError(val messages: List<String>, val spreadsheetLineNumber: Int)
+}
+
+class PatentSheetsRepository(val spreadsheetReader: SpreadsheetReader) :
+    CollectableRepository<Patent, PatentSheetsError> {
+    companion object {
+        /**
+         * Index of the first row that contains data.
+         *
+         * Google Sheets' rows are 1-based indexed and we skip the first row, since it contains the
+         * labels, so we end up with 2.
+         */
+        private const val INDEX_CORRECTION_FACTOR = 2
+    }
+
+    override fun collect(): Pair<Set<Patent>, List<PatentSheetsError>> {
+        val validPatents = mutableSetOf<Patent>()
+        val errors = mutableListOf<PatentSheetsError>()
+
+        this.spreadsheetReader.read(Sheets.Patents).drop(1).forEach { row ->
+            Patent.fromRow(row)
+                .onSuccess { v -> validPatents += v }
+                .onFailure { e ->
+                    when (e) {
+                        is ValidationException -> {
+                            errors +=
+                                PatentSheetsError.ValidationError(
+                                    message = e.message, spreadsheetLineNumber = 3)
+                        }
+                        else -> {
+                            errors +=
+                                PatentSheetsError.ValidationError(
+                                    message = e.message, spreadsheetLineNumber = 3)
+                        }
+                    }
+                }
+        }
+
+        return validPatents.toSet() to errors
+    }
+}


### PR DESCRIPTION
Closes #203
This PR tries to refresh the patents using the kotlin backend, so we can migrate away from Ruby.

I did some experimental refactoring on the Repository pattern to see if there's any way to make it better
- Sealed classes to represent Validation and Uniqueness errors (to avoid having to use `Any`)
- Empty companion object to allow extending a **static** `fromRow()` directly from the catalog model (to avoid re-defining the model again)
- Abuse of generic interfaces to possibly achieve a generic `sync() / refresh()` function that works for any Repository that stores the same kind of data. That way we could transfer data from a `GoogleSheetRepository<Patent>` to a `MongoRepository<Patent>` or to any `Repository<Patent>` that implements the right interfaces.
- Trying out error handling with kotlin's Result class (I was hoping it would be similar to Rust)

Error handling has been a bit tough though, I'm working on that.

If the refactoring fails (or if it's too much work) I'll just drop it and implement it like the other refreshers. (e.g. RefreshCompany)

Work in progress...
(rebase required after #282)