### PR TITLE
server: hub-app: resources/application.conf: Add default email.{devs,username,password}

### DIFF
--- a/server/hub-app/src/main/resources/application.conf
+++ b/server/hub-app/src/main/resources/application.conf
@@ -11,8 +11,13 @@ ktor {
     }
 }
 email {
+    devs = ""
     devs = ${?HUB_DEVS_EMAIL}
+
+    username = ""
     username = ${?HUB_EMAIL_ADDRESS}
+
+    password = ""
     password = ${?HUB_EMAIL_PASSWORD}
 }
 jwt {


### PR DESCRIPTION
The tests seems to fail without it

(I'm not quite sure why the test depends on `ConfigureRouting`, I see no explicit call to it)