### PR TITLE
frontend: store: company_data: Set initial `category` state

### DIFF
--- a/frontend/store/company_forms/company_data.js
+++ b/frontend/store/company_forms/company_data.js
@@ -15,6 +15,7 @@ const state = () => ({
     state: "",
     cep: "",
   },
+  category: "",
   company_nature: "",
 });
 


### PR DESCRIPTION
Fixes #318

without this, `setCategory` won't work if you `yarn build`

I hate that it works completely fine on `yarn dev`, but fails on prod...