### PR TITLE
add try except to avoid erros on mail

### DIFF
--- a/server/mailer/src/main/kotlin/br/usp/inovacao/hubusp/mailer/Mailer.kt
+++ b/server/mailer/src/main/kotlin/br/usp/inovacao/hubusp/mailer/Mailer.kt
@@ -76,13 +76,19 @@ class Mailer(private val user: String, private val password: String) {
     // If the mail fails to send for whatever reason this throws an error.
     // We should catch it and return some Status object.
     fun send(mail: Mail) {
-        val session = Session.getInstance(config, auth)
-        val message = buildMessage(session, mail)
-        val transport = session.getTransport(protocol)
-        with(transport) {
-            connect(host, user, password)
-            sendMessage(message, message.allRecipients)
-            close()
+        try {
+            val session = Session.getInstance(config, auth)
+            val message = buildMessage(session, mail)
+            val transport = session.getTransport(protocol)
+
+            with(transport) {
+                connect(host, user, password)
+                sendMessage(message, message.allRecipients)
+                close()
+            }
+        } catch (e: Exception) {
+            println("Failed to send email: ${e.message}")
+            e.printStackTrace()
         }
     }
 }


### PR DESCRIPTION
fix 502 error when an email was not passed on the server/.env and when a password (not a app password) was passed on HUB_EMAIL_PASSWORD of server/.env