### PR TITLE
feat: test coverage with kover

### DIFF
--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -22,12 +22,29 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+
+      - name: Setup JDK
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+          cache: 'gradle'
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2
 
       - name: gradle build
-        run: |
-          cd server && ./gradlew build
+        run: cd server && ./gradlew build
 
+      - name: Generate coverage report
+        run: cd server && ./gradlew koverXmlReport koverHtmlReport
+
+      - name: Verify coverage threshold
+        run: cd server && ./gradlew koverVerify
+
+      - name: Upload coverage report
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: server/build/reports/kover/html

--- a/.github/workflows/kotlin-ci.yml
+++ b/.github/workflows/kotlin-ci.yml
@@ -8,18 +8,18 @@ on:
     paths:
       - 'server/**'
 
+permissions:
+  contents: read
+
 jobs:
-
   build:
-    name: Kotlin build 
+    name: Kotlin build
     runs-on: ubuntu-latest
-
     services:
       mongo:
         image: mongo
         ports:
           - 27017:27017
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -37,11 +37,11 @@ jobs:
       - name: gradle build
         run: cd server && ./gradlew build
 
-      - name: Generate coverage report
-        run: cd server && ./gradlew koverXmlReport koverHtmlReport
+      - name: Run tests
+        run: cd server && ./gradlew test
 
-      - name: Verify coverage threshold
-        run: cd server && ./gradlew koverVerify
+      - name: Generate coverage report
+        run: cd server && ./gradlew test koverHtmlReport
 
       - name: Upload coverage report
         uses: actions/upload-artifact@v4

--- a/dockers.sh
+++ b/dockers.sh
@@ -1,0 +1,6 @@
+sudo docker compose run catalogcli refresh-pdi &
+sudo docker compose run catalogcli refresh-company &
+sudo docker compose run catalogcli refresh-researcher &
+sudo docker compose run catalogcli refresh-initiative &
+sudo docker compose run catalogcli refresh-patent &
+sudo docker compose run catalogcli refresh-discipline

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -2,7 +2,6 @@ plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.serialization)
     alias(libs.plugins.dokka)
-    alias(libs.plugins.kover)
 }
 
 repositories {
@@ -23,15 +22,4 @@ dependencies {
     kover(project(":persistence"))
     kover(project(":sheets"))
     kover(project(":techtransfer"))
-}
-
-
-kover {
-    reports {
-        verify {
-            rule {
-                minBound(0)
-            }
-        }
-    }
 }

--- a/server/build.gradle.kts
+++ b/server/build.gradle.kts
@@ -2,6 +2,7 @@ plugins {
     alias(libs.plugins.jvm)
     alias(libs.plugins.serialization)
     alias(libs.plugins.dokka)
+    alias(libs.plugins.kover)
 }
 
 repositories {
@@ -9,4 +10,28 @@ repositories {
     maven { url = uri("https://maven.pkg.jetbrains.space/public/p/ktor/eap") }
 }
 
-dependencies { allprojects { dokka(project) } }
+dependencies {
+    allprojects { dokka(project) }
+
+    kover(project(":catalog"))
+    kover(project(":config"))
+    kover(project(":curatorship"))
+    kover(project(":discovery"))
+    kover(project(":hub-app"))
+    kover(project(":hub-cli"))
+    kover(project(":mailer"))
+    kover(project(":persistence"))
+    kover(project(":sheets"))
+    kover(project(":techtransfer"))
+}
+
+
+kover {
+    reports {
+        verify {
+            rule {
+                minBound(0)
+            }
+        }
+    }
+}

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -5,8 +5,6 @@ hoplite = "2.8.2"
 
 ktor = "3.2.3"
 
-kover = "0.8.3"
-
 [libraries]
 mockk = { module = "io.mockk:mockk", version = "1.14.6" }
 junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
@@ -80,4 +78,3 @@ jvm = { id = "org.jetbrains.kotlin.jvm",  version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version = "2.1.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.0.0" }
-kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/server/gradle/libs.versions.toml
+++ b/server/gradle/libs.versions.toml
@@ -5,6 +5,8 @@ hoplite = "2.8.2"
 
 ktor = "3.2.3"
 
+kover = "0.8.3"
+
 [libraries]
 mockk = { module = "io.mockk:mockk", version = "1.14.6" }
 junit = { module = "org.jetbrains.kotlin:kotlin-test-junit", version.ref = "kotlin" }
@@ -78,3 +80,4 @@ jvm = { id = "org.jetbrains.kotlin.jvm",  version.ref = "kotlin" }
 serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 dokka = { id = "org.jetbrains.dokka", version = "2.1.0" }
 shadow = { id = "com.github.johnrengelman.shadow", version = "7.0.0" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/server/settings.gradle.kts
+++ b/server/settings.gradle.kts
@@ -1,14 +1,44 @@
 rootProject.name = "br.usp.inovacao.hubusp.server"
 
-include(
-    "catalog",
-    "config",
-    "curatorship",
-    "discovery",
-    "hub-app",
-    "hub-cli",
-    "mailer",
-    "persistence",
-    "sheets",
-    "techtransfer",
-)
+plugins {
+    id("org.jetbrains.kotlinx.kover.aggregation") version "0.9.1"
+}
+
+include(":catalog")
+include(":config")
+include(":curatorship")
+include(":discovery")
+include(":hub-app")
+include(":hub-cli")
+include(":mailer")
+include(":persistence")
+include(":sheets")
+include(":techtransfer")
+
+kover{
+    enableCoverage()
+
+    reports{
+        includedProjects.addAll(
+            ":catalog",
+            ":config",
+            ":curatorship",
+            ":discovery",
+            ":hub-app",
+            ":hub-cli",
+            ":mailer",
+            ":persistence",
+            ":sheets",
+            ":techtransfer"
+        )
+
+        verify {
+            rule {
+                name = "Minimal line coverage rate in percentage"
+                bound {
+                    minValue = 0
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR adds test coverage to for the Kotlin CI via Github Actions with the Kover tool.

Quick nit: for now, letting the coverage min bound at 0% as the tests for some classes are pretty poor. Plus, the current `master` branch does not feature the Kotlin migration, so this avoids breaking the CI at the moment.