### PR TITLE
fix(payload): build do payload com erro por causa de falta do standal…

### DIFF
--- a/payload/Dockerfile
+++ b/payload/Dockerfile
@@ -69,18 +69,3 @@ ENV PORT 3000
 # server.js is created by next build from the standalone output
 # https://nextjs.org/docs/pages/api-reference/next-config-js/output
 CMD HOSTNAME="0.0.0.0" node server.js
-
-FROM node:20-alpine
-
-WORKDIR /app
-
-COPY package*.json ./
-RUN npm install
-
-RUN mkdir -p .next && chown node:node .next
-
-COPY . .
-
-EXPOSE 3002
-
-CMD ["npm", "run", "dev"]

--- a/payload/next.config.ts
+++ b/payload/next.config.ts
@@ -7,6 +7,7 @@ const __filename = fileURLToPath(import.meta.url)
 const dirname = path.dirname(__filename)
 
 const nextConfig: NextConfig = {
+  output: 'standalone',
   basePath: '/cms',
   images: {
     localPatterns: [


### PR DESCRIPTION
build do payload estava dando erro na VM por causa de falta do standalone na configuração do Next.js. Alem disso, arruma o dockerfile que estava errado e poderia gerar erros