### PR TITLE
fix(frontend): exibe imagem original no card do blog

### DIFF
--- a/frontend/components/blog/PostCard.vue
+++ b/frontend/components/blog/PostCard.vue
@@ -66,11 +66,12 @@ export default {
         this.thumbnailURL = await this.$BlogAdapter.getMediaThumbnailURL(
           this.post.thumbnail
         );
-      } else if (
-        this.post.thumbnail.sizes &&
-        this.post.thumbnail.sizes.thumbnail
-      ) {
-        this.thumbnailURL = this.$BlogAdapter.getAbsoluteImageUrl(this.post.thumbnail.sizes.thumbnail.url);
+      } else {
+        const thumbnailPath =
+          this.post.thumbnail.sizes?.thumbnail?.url ||
+          this.post.thumbnail.url;
+        this.thumbnailURL =
+          this.$BlogAdapter.getAbsoluteImageUrl(thumbnailPath);
       }
     }
   },


### PR DESCRIPTION
## O que mudou

- mantém o uso do thumbnail 400x300 quando ele é gerado pelo Payload
- usa a URL da imagem original quando o thumbnail não possui URL

## Contexto

O Payload não amplia imagens menores que 400x300 por padrão. Nesses casos, o objeto `sizes.thumbnail` existe, mas sua `url` é nula. O card interpretava essa URL vazia como ausência de imagem e exibia o placeholder, enquanto a página do post conseguia usar a imagem original.

## Validação

- validação isolada do componente com thumbnail gerado
- validação do fallback para a imagem original
- validação do relacionamento de mídia retornado como ID
- `git diff --check`